### PR TITLE
FIX: remove unused argparse arguments

### DIFF
--- a/run_1_dicomConvert.py
+++ b/run_1_dicomConvert.py
@@ -346,18 +346,6 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        '--use_patient_names',
-        action='store_true',
-        help='Use the PatientName rather than PatientID for subject folders'
-    )
-
-    parser.add_argument(
-        '--use_session_dates',
-        action='store_true',
-        help='Use the StudyDate field rather than an incrementer for session IDs'
-    )
-
-    parser.add_argument(
         '--auto_yes',
         action='store_true',
         help='Force running non-interactively'


### PR DESCRIPTION
Arguments  `--use_patient_names`  and `--use_session_dates` are defined but never used. They might have be copy/pasted from the [run_0_dicomSort.py](https://github.com/QSMxT/QSMxT/blob/master/run_0_dicomSort.py) script where they are indeed used.  

I would suggest excluding them from the script for clarity purposes. 