### PR TITLE
Fix runs-on and use unique labels for cirun

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -5,4 +5,4 @@ runners:
     machine_image: ocid1.image.oc1.eu-frankfurt-1.aaaaaaaa6m57xzoztlide4653fjavkm6dpksmz3kaa4gig4h34jod76aapva
     region: eu-frankfurt-1
     labels:
-      - oracle
+      - cirun-oracle

--- a/.github/workflows/test_segmentation_pipeline.yml
+++ b/.github/workflows/test_segmentation_pipeline.yml
@@ -30,7 +30,7 @@ on:
     
 jobs:
   test_segmentation_pipeline:
-    runs-on: [self-hosted, oracle]
+    runs-on: "cirun-oracle--${{ github.run_id }}"
     steps:
     - name: segmentation pipeline
       run: |


### PR DESCRIPTION
The reason this job is stuck:
https://github.com/QSMxT/QSMxT/actions/runs/3643628730/jobs/6152044092

Is because the runner (`cirun-qsmxt--qsmxt-1508f0d`) created for this job was consumed by this workflow:
https://github.com/QSMxT/QSMxT/actions/runs/3643542981/jobs/6151877226

The unique label (`--${{ github.run_id }}`) appended makes sure that it is consumed the the workflow it was created by.

cc @stebo85 