### PR TITLE
change scale factor for nextqsm pipeline to 1e6/(2*np.pi)

### DIFF
--- a/qsmxt/workflows/qsm.py
+++ b/qsmxt/workflows/qsm.py
@@ -1102,7 +1102,7 @@ def qsm_workflow(run_args, name, magnitude_available, use_maps, dimensions_phase
         normalize_phase_threads = min(2, run_args.n_procs) if run_args.multiproc else 2
         mn_normalize_phase = create_node(
             interface=processphase.PhaseToNormalizedInterface(
-                scale_factor=1e6 if run_args.qsm_algorithm == 'nextqsm' else 1e6/(2*np.pi)
+                scale_factor=1e6/(2*np.pi)
             ),
             name='nibabel-numpy_normalize-phase',
             iterfield=['phase', 'TE'],
@@ -1127,7 +1127,7 @@ def qsm_workflow(run_args, name, magnitude_available, use_maps, dimensions_phase
         normalize_freq_threads = min(2, run_args.n_procs) if run_args.multiproc else 2
         mn_normalize_freq = create_node(
             interface=processphase.FreqToNormalizedInterface(
-                scale_factor=1e6 if run_args.qsm_algorithm == 'nextqsm' else 1e6/(2*np.pi)
+                scale_factor=1e6/(2*np.pi)
             ),
             name='nibabel-numpy_normalize-freq',
             iterfield=['frequency'],


### PR DESCRIPTION
QSM challenge data was used to simulate testing data. Comparison of scale factor of 1e6 and 1e6/(2*np.pi) as following:  

Command line for combined phase:  
` qsmxt bids qsmxt_output_nextqsm_gtmask-combined --premade 'nextqsm' --mask_erosions 0 --use_existing_masks --auto_yes
`
Command line for single echo:  
` qsmxt bids qsmxt_output_nextqsm_gtmask_phase --premade 'nextqsm' --combine_phase off --mask_erosions 0 --use_existing_masks --auto_yes
`

  
QSM qualitative comparison:  
![image](https://github.com/user-attachments/assets/a90bcd8e-629c-4722-a185-95418edb4269)

QSM quantitative comparison:  
|Item|RMSE|HFEN|XSIM|
| ------ | ------ | ------ | ------ |
|single echo 1e6|0.0415|1.322|0.6028|
|single echo 1e6/(2*np.pi)|0.0228|0.6344|0.7416|
|combined phase 1e6|0.0415|1.319|0.6042|
|combined phase 1e6/(2*np.pi)|0.0230|0.6408|0.7366|

