### PR TITLE
chore: bump qsm-core to v0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,7 +1789,7 @@ dependencies = [
 [[package]]
 name = "qsm-core"
 version = "0.0.0"
-source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.18.0#60a53476a94b0083518ba4d5a657c31581aa3f87"
+source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.19.0#97fc5e33376563614fde05eb3a211e757c9738a1"
 dependencies = [
  "bytemuck",
  "delaunator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "qsmxt"
 path = "src/main.rs"
 
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.18.0", features = ["parallel"] }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.19.0", features = ["parallel"] }
 qsmxt-config = { path = "crates/qsmxt-config" }
 clap = { version = "4", features = ["derive"] }
 const_format = "0.2"

--- a/crates/qsmxt-config/Cargo.toml
+++ b/crates/qsmxt-config/Cargo.toml
@@ -6,7 +6,7 @@ description = "Pipeline configuration, command generation, and methods text for 
 license = "GPL-3.0-only"
 
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.18.0" }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.19.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"


### PR DESCRIPTION
Updates the `qsm-core` git dependency (root `Cargo.toml` + `crates/qsmxt-config`) from **v0.18.0 → v0.19.0**, and refreshes `Cargo.lock` (rev `97fc5e3`).

## Behavioral changes inherited from qsm-core v0.19.0
qsmxt uses `qsm_core::inversion::TgvParams::default()` and passes algorithm params through unchanged, so it picks these up automatically — no hardcoded values to sync:

- **iLSQR** ([QSM.rs#48](https://github.com/astewartau/QSM.rs/pull/48)): fixed premature LSQR convergence — better dipole inversion (`--qsm-algorithm ilsqr`), and it's also the inversion inside the QSMART pipeline.
- **TGV** ([QSM.rs#47](https://github.com/astewartau/QSM.rs/pull/47)): default regularization set to the Langkammer reference (`alpha1` 0.0005, `alpha0` 0.0015), restoring contrast for `--qsm-algorithm tgv` at defaults. Users passing `--tgv-alpha0/--tgv-alpha1` are unaffected.

See the [QSM.rs v0.19.0 release](https://github.com/astewartau/QSM.rs/releases/tag/v0.19.0).

## Verification
- No API changes; `cargo check --workspace` builds clean.
- All 91 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)