### PR TITLE
ci: legacy pip publish workflow + skip Rust release on non-Rust tags

### DIFF
--- a/.github/workflows/publish-legacy.yml
+++ b/.github/workflows/publish-legacy.yml
@@ -1,0 +1,63 @@
+name: Publish legacy pip package
+
+# Publishes the legacy Python (v8.x) QSMxT package to PyPI.
+#
+# The old release-triggered publish workflow (python-publish.yml) lives only on
+# the python-legacy branch. GitHub only runs `release`-triggered workflows that
+# exist on the DEFAULT branch, and main is now the Rust rewrite — so publishing
+# a GitHub release no longer publishes the pip package. This manually-dispatched
+# workflow lives on the default branch (so it is dispatchable) and checks out the
+# legacy branch/tag itself to build and upload it.
+#
+# Run it from the Actions tab ("Run workflow") or with:
+#   gh workflow run publish-legacy.yml -f ref=python-legacy
+# Point `ref` at a branch (python-legacy) or a specific tag (e.g. v8.3.4).
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Legacy branch or tag to build and publish from"
+        required: true
+        default: python-legacy
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Verify this is the legacy Python line
+        shell: bash
+        run: |
+          if [ ! -f setup.py ] || [ -f Cargo.toml ]; then
+            echo "::error::ref '${{ inputs.ref }}' does not look like the legacy Python line (expected setup.py and no Cargo.toml). Refusing to publish."
+            exit 1
+          fi
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build
+
+      - name: Build package
+        env:
+          # setup.py reads the version from docs/_config.yml keyed by this var
+          REQUIRED_VERSION_TYPE: DEPLOY_PACKAGE_VERSION
+        run: python -m build
+
+      - name: Show artifacts to be published
+        run: ls -l dist/
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,32 @@ permissions:
   contents: write
 
 jobs:
+  # Releases are a repository-level event, so GitHub runs this workflow (from
+  # the default branch) for EVERY published release — including tags cut from
+  # the python-legacy line (v8.x), which have no Cargo project. Detect that and
+  # skip the Rust jobs so a legacy release doesn't produce a failing run.
+  # Legacy pip publishing is handled separately by publish-legacy.yml.
+  guard:
+    name: Guard (Rust release only)
+    runs-on: ubuntu-latest
+    outputs:
+      is_rust: ${{ steps.check.outputs.is_rust }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        shell: bash
+        run: |
+          if [ -f Cargo.toml ]; then
+            echo "is_rust=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_rust=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No Cargo.toml at ${GITHUB_REF_NAME} — skipping the Rust release workflow (legacy python-legacy tag). Use the 'Publish legacy pip package' workflow to publish to PyPI."
+          fi
+
   coverage-gate:
     name: Coverage Gate (90%)
+    needs: guard
+    if: needs.guard.outputs.is_rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Why

Follow-up to the v8.3.4 legacy fix (#175). Two problems with releasing on the legacy Python line now that `main` is the Rust rewrite:

1. **Publishing a GitHub release no longer publishes the pip package.** `release`-triggered workflows only run if the workflow file exists on the **default branch**. The old `python-publish.yml` lives only on `python-legacy`, so it never fires.
2. **The Rust `release.yml` fires for every published release** (it's on the default branch) and **fails** on a legacy v8.x tag because there's no Cargo project there.

## Changes

- **`release.yml`** — new `guard` job that checks for `Cargo.toml`; the Rust jobs are gated on it (`if: needs.guard.outputs.is_rust == 'true'`). Legacy (v8.x) tags with no Cargo project are now cleanly skipped instead of failing. Future-proof (works for v9/v10/... — keys off the Cargo project, not a tag pattern).
- **`publish-legacy.yml`** — new `workflow_dispatch` workflow on the default branch (required for it to be dispatchable). Checks out a chosen legacy branch/tag, verifies it's the Python line (`setup.py` present, no `Cargo.toml`), builds, and uploads to PyPI via the existing `PYPI_API_TOKEN` secret.

## Usage (after merge)

```
gh workflow run publish-legacy.yml -f ref=python-legacy   # or -f ref=v8.3.4
```

or via the Actions tab → "Publish legacy pip package" → Run workflow.

> Note: `publish-legacy.yml` only becomes dispatchable once merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)