### PR TITLE
feat: support all QSM.rs v0.27.1 algorithms (mSMV + full DL model set)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +110,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "anymap2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
+
+[[package]]
+name = "anymap3"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5dfbc6d8d2675589ccbe4d0fd61df2419075625f8c1a62325e718e2b0049f9"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,7 +144,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -144,7 +168,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "log",
- "nom",
+ "nom 8.0.0",
  "num-rational",
  "v_frame",
 ]
@@ -163,6 +187,21 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit_field"
@@ -187,6 +226,15 @@ name = "bitstream-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "built"
@@ -320,7 +368,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -390,6 +438,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +512,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,7 +541,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -485,7 +552,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -495,6 +562,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e1ee323c1275374f7e612d3724d12707079fb6a2117349fe144def656f5a880"
 dependencies = [
  "robust",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive-new"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -671,6 +755,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "dyn-hash"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15401da73a9ed8c80e3b2d4dc05fe10e7b72d7243b9f614e516a44fa99986e88"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,7 +915,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -836,6 +965,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +995,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures-core"
@@ -879,6 +1027,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -931,7 +1089,17 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]
@@ -988,6 +1156,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,6 +1249,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "image"
@@ -1078,7 +1350,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1089,7 +1361,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1123,6 +1395,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1178,7 +1459,7 @@ checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1391,6 +1672,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,6 +1732,69 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "liquid"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e9338405fdbc0bce9b01695b2a2ef6b20eca5363f385d47bce48ddf8323cc25"
+dependencies = [
+ "doc-comment",
+ "liquid-core",
+ "liquid-derive",
+ "liquid-lib",
+ "serde",
+]
+
+[[package]]
+name = "liquid-core"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feb8fed70857010ed9016ed2ce5a7f34e7cc51d5d7255c9c9dc2e3243e490b42"
+dependencies = [
+ "anymap2",
+ "itertools 0.13.0",
+ "kstring",
+ "liquid-derive",
+ "num-traits",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "liquid-derive"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b51f1d220e3fa869e24cfd75915efe3164bd09bb11b3165db3f37f57bf673e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "liquid-lib"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee1794b5605e9f8864a8a4f41aa97976b42512cc81093f8c885d29fb94c6c556"
+dependencies = [
+ "itertools 0.13.0",
+ "liquid-core",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "time",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -1470,6 +1830,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,6 +1860,21 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1560,6 +1941,16 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
@@ -1594,6 +1985,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,7 +1998,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1631,6 +2028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1691,6 +2089,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
+dependencies = [
+ "pest",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,6 +2177,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,7 +2207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1783,13 +2244,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "qsm-core"
 version = "0.0.0"
-source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.26.0#5f28561f7c85f572ae3997e85a9daee6aaab9c91"
+source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.27.1#d603de84352f3a1c9e15107bef0daeefb1f3a61c"
 dependencies = [
  "bytemuck",
  "delaunator",
@@ -1801,6 +2285,9 @@ dependencies = [
  "rayon",
  "rustfft",
  "serde",
+ "sha2",
+ "tract-onnx",
+ "ureq",
 ]
 
 [[package]]
@@ -1895,6 +2382,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -2042,6 +2539,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "robust"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2088,6 +2599,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,6 +2650,24 @@ name = "safe-transmute"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scan_fmt"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b53b0a5db882a8e2fdaae0a43f7b39e7e9082389e978398bdf223a55b581248"
+dependencies = [
+ "regex",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2144,7 +2708,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2168,6 +2732,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2252,8 +2827,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -2266,6 +2847,17 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "string-interner"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f9fdfdd31a0ff38b59deb401be81b73913d76c9cc5b1aed4e1330a223420b9"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "serde",
+]
 
 [[package]]
 name = "strsim"
@@ -2292,8 +2884,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
@@ -2316,6 +2914,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -2323,6 +2932,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2336,6 +2967,17 @@ dependencies = [
  "pkg-config",
  "toml",
  "version-compare",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2393,7 +3035,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2404,7 +3046,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2417,6 +3059,61 @@ dependencies = [
  "jpeg-decoder",
  "weezl",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
@@ -2478,7 +3175,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2488,6 +3185,143 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tract-core"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7b5347639690871b124593a8c8903f1f369531498b8abaebd18eb5c58163971"
+dependencies = [
+ "anyhow",
+ "anymap3",
+ "bit-set",
+ "derive-new",
+ "downcast-rs",
+ "dyn-clone",
+ "lazy_static",
+ "log",
+ "maplit",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "rustfft",
+ "smallvec",
+ "tract-data",
+ "tract-linalg",
+]
+
+[[package]]
+name = "tract-data"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a3f476a1804e05708e9bc5e2d29dcab82bad531e357d3d14d7da80fbba0b6d"
+dependencies = [
+ "anyhow",
+ "downcast-rs",
+ "dyn-clone",
+ "dyn-hash",
+ "half",
+ "itertools 0.12.1",
+ "lazy_static",
+ "maplit",
+ "ndarray",
+ "nom 7.1.3",
+ "num-integer",
+ "num-traits",
+ "parking_lot",
+ "scan_fmt",
+ "smallvec",
+ "string-interner",
+]
+
+[[package]]
+name = "tract-hir"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dca047ba1151fe3446fb0194d4b6ddb9ae8f361337c47a267870c53605fbafb"
+dependencies = [
+ "derive-new",
+ "log",
+ "tract-core",
+]
+
+[[package]]
+name = "tract-linalg"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8e0703eb53ef1bbf77050ff261675818dd5f0d6c27044c6e48ede9b845f9e0"
+dependencies = [
+ "byteorder",
+ "cc",
+ "derive-new",
+ "downcast-rs",
+ "dyn-clone",
+ "dyn-hash",
+ "half",
+ "lazy_static",
+ "liquid",
+ "liquid-core",
+ "liquid-derive",
+ "log",
+ "num-traits",
+ "paste",
+ "rayon",
+ "scan_fmt",
+ "smallvec",
+ "time",
+ "tract-data",
+ "unicode-normalization",
+ "walkdir",
+]
+
+[[package]]
+name = "tract-nnef"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cb88a4367ec2c695610223cf886f01fc1deb5c9a82c7a74b1a5d32dc0b1466"
+dependencies = [
+ "byteorder",
+ "flate2",
+ "log",
+ "nom 7.1.3",
+ "tar",
+ "tract-core",
+ "walkdir",
+]
+
+[[package]]
+name = "tract-onnx"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5830aa672b2aa4dc98a97a36e5988eaf77b3ecee65e2601619588d2ca557008"
+dependencies = [
+ "bytes",
+ "derive-new",
+ "log",
+ "memmap2",
+ "num-integer",
+ "prost",
+ "smallvec",
+ "tract-hir",
+ "tract-nnef",
+ "tract-onnx-opl",
+]
+
+[[package]]
+name = "tract-onnx-opl"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121d3d224c806ba3d941f4bb50943ad33b59d1da5ae704d0e4e76d2808221f96"
+dependencies = [
+ "getrandom 0.2.17",
+ "log",
+ "rand",
+ "rand_distr",
+ "rustfft",
+ "tract-nnef",
 ]
 
 [[package]]
@@ -2501,10 +3335,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -2542,6 +3397,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2563,6 +3458,22 @@ name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -2620,7 +3531,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2678,6 +3589,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,6 +3627,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2726,7 +3664,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2737,7 +3675,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2762,6 +3700,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
@@ -2891,7 +3838,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2907,7 +3854,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2950,6 +3897,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2966,7 +3952,67 @@ checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "qsmxt"
 path = "src/main.rs"
 
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.26.0", features = ["parallel"] }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.27.1", features = ["parallel", "onnx", "download"] }
 qsmxt-config = { path = "crates/qsmxt-config" }
 clap = { version = "4", features = ["derive"] }
 const_format = "0.2"

--- a/crates/qsmxt-config/Cargo.toml
+++ b/crates/qsmxt-config/Cargo.toml
@@ -6,7 +6,7 @@ description = "Pipeline configuration, command generation, and methods text for 
 license = "GPL-3.0-only"
 
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.26.0" }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.27.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"

--- a/crates/qsmxt-config/src/bridge.rs
+++ b/crates/qsmxt-config/src/bridge.rs
@@ -47,6 +47,19 @@ fn map_alg(alg: QsmAlgorithm) -> PInvAlg {
         QsmAlgorithm::Whqsm => PInvAlg::Whqsm,
         QsmAlgorithm::Hdqsm => PInvAlg::Hdqsm,
         QsmAlgorithm::AmpPe => PInvAlg::AmpPe,
+        QsmAlgorithm::Xqsm => PInvAlg::Xqsm,
+        QsmAlgorithm::Qsmnet => PInvAlg::Qsmnet,
+        QsmAlgorithm::QsmnetPlus => PInvAlg::QsmnetPlus,
+        QsmAlgorithm::Autoqsm => PInvAlg::Autoqsm,
+        QsmAlgorithm::Qsmgan => PInvAlg::Qsmgan,
+        QsmAlgorithm::Ir2qsm => PInvAlg::Ir2qsm,
+        QsmAlgorithm::Lpcnn => PInvAlg::Lpcnn,
+        QsmAlgorithm::ModlQsm => PInvAlg::ModlQsm,
+        QsmAlgorithm::Nextqsm => PInvAlg::Nextqsm,
+        // End-to-end from phase — the runner calls run_iqsm/run_iqsm_plus directly and
+        // never routes these through run_dipole_inversion (which rejects them).
+        QsmAlgorithm::Iqsm => PInvAlg::Iqsm,
+        QsmAlgorithm::IqsmPlus => PInvAlg::IqsmPlus,
     }
 }
 
@@ -104,6 +117,11 @@ pub fn to_pipeline_stages(cfg: &PipelineConfig) -> (
             BfAlgorithm::Resharp => PBgAlg::Resharp,
             BfAlgorithm::Harperella => PBgAlg::Harperella,
             BfAlgorithm::Iharperella => PBgAlg::Iharperella,
+            BfAlgorithm::Bfrnet => PBgAlg::Bfrnet,
+            // iQFM has no qsm-core BgRemovalAlgorithm (its input is phase, not a total field):
+            // the qsmxt runner intercepts it and calls run_iqfm, so this value is never used.
+            // Map to a harmless placeholder to keep the config well-formed.
+            BfAlgorithm::Iqfm => PBgAlg::Vsharp,
         },
         vsharp: qsm_core::bgremove::VsharpParams {
             threshold: cfg.bg_removal.vsharp.threshold,
@@ -133,11 +151,15 @@ pub fn to_pipeline_stages(cfg: &PipelineConfig) -> (
             tol: cfg.bg_removal.harperella.tol,
         },
         sdf: qsm_core::bgremove::SdfParams::default(),
-        // mSMV is a refinement-only post-step in qsm-core v0.26; not yet exposed as a
-        // qsmxt knob, so use defaults and leave the refinement off (b0/te are overridden
-        // from scan metadata by the dispatcher when enabled).
-        msmv: qsm_core::bgremove::MsmvParams::default(),
-        msmv_refine: false,
+        // mSMV boundary-shadow refinement (Roberts 2024), applied on top of the primary BFR
+        // when enabled. b0/te are overridden from scan metadata and prefilter is forced off
+        // (refinement mode) by the qsm-core dispatcher; only radius/maxk come from config.
+        msmv: qsm_core::bgremove::MsmvParams {
+            radius: cfg.bg_removal.msmv.radius,
+            maxk: cfg.bg_removal.msmv.maxk,
+            ..qsm_core::bgremove::MsmvParams::default()
+        },
+        msmv_refine: cfg.bg_removal.msmv_refine,
     };
 
     let inversion = PInversion {
@@ -287,6 +309,8 @@ fn map_sep_alg(alg: SeparationAlgorithm) -> PSepAlg {
         SeparationAlgorithm::WaveSep => PSepAlg::WaveSep,
         SeparationAlgorithm::Decompose => PSepAlg::Decompose,
         SeparationAlgorithm::HcChisep => PSepAlg::HcChisep,
+        SeparationAlgorithm::SusepNet => PSepAlg::SusepNet,
+        SeparationAlgorithm::ChiSepNet => PSepAlg::ChiSepNet,
     }
 }
 

--- a/crates/qsmxt-config/src/command.rs
+++ b/crates/qsmxt-config/src/command.rs
@@ -118,6 +118,15 @@ pub fn generate_command(config: &PipelineConfig) -> String {
             emit_usize(&mut parts, "--iharperella-max-iter", config.bg_removal.iharperella.max_iter, d.bg_removal.iharperella.max_iter);
             emit_f64(&mut parts, "--iharperella-tol", config.bg_removal.iharperella.tol, d.bg_removal.iharperella.tol);
         }
+        // BFRnet / iQFM (deep learning) have no user-tunable parameters.
+        BfAlgorithm::Bfrnet | BfAlgorithm::Iqfm => {}
+    }
+    // mSMV boundary-shadow refinement is a post-step on any primary BFR (not part of the
+    // match above); emit its flag + params only when enabled.
+    if config.bg_removal.msmv_refine {
+        parts.push("--msmv-refine".into());
+        emit_f64(&mut parts, "--msmv-radius", config.bg_removal.msmv.radius, d.bg_removal.msmv.radius);
+        emit_usize(&mut parts, "--msmv-maxk", config.bg_removal.msmv.maxk, d.bg_removal.msmv.maxk);
     }
 
     // ── QSM inversion ──
@@ -270,6 +279,12 @@ pub fn generate_command(config: &PipelineConfig) -> String {
             emit_f64(&mut parts, "--amp-pe-cvg-thd", a.cvg_thd, da.cvg_thd);
             emit_f64(&mut parts, "--amp-pe-tikhonov-beta", a.tikhonov_beta, da.tikhonov_beta);
         }
+        // Deep-learning inversions have no user-tunable parameters (weights + fixed graph).
+        QsmAlgorithm::Xqsm | QsmAlgorithm::Qsmnet
+        | QsmAlgorithm::QsmnetPlus | QsmAlgorithm::Autoqsm
+        | QsmAlgorithm::Qsmgan | QsmAlgorithm::Ir2qsm | QsmAlgorithm::Lpcnn
+        | QsmAlgorithm::ModlQsm | QsmAlgorithm::Nextqsm
+        | QsmAlgorithm::Iqsm | QsmAlgorithm::IqsmPlus => {}
     }
 
     // ── Chi-separation method + params (only the selected method's) ──
@@ -323,6 +338,8 @@ pub fn generate_command(config: &PipelineConfig) -> String {
                 emit_f64(&mut parts, "--hc-chisep-dr-pos-3t", s.hc_chisep.dr_pos_3t, ds.hc_chisep.dr_pos_3t);
                 emit_f64(&mut parts, "--hc-chisep-bin-hz", s.hc_chisep.bin_hz, ds.hc_chisep.bin_hz);
             }
+            // SUSEP-Net / χ-sepnet (deep learning) have no user-tunable parameters.
+            SeparationAlgorithm::SusepNet | SeparationAlgorithm::ChiSepNet => {}
         }
     }
 
@@ -375,6 +392,21 @@ mod tests {
         config.inversion.algorithm = QsmAlgorithm::Tv;
         let cmd = generate_command(&config);
         assert!(cmd.contains("--qsm-algorithm tv"));
+    }
+
+    #[test]
+    fn test_msmv_refine_command() {
+        // Off by default → no mSMV flags.
+        let mut config = PipelineConfig::default();
+        assert!(!generate_command(&config).contains("--msmv"));
+        // Enabled → the refine flag is emitted; a non-default param is emitted too.
+        config.bg_removal.msmv_refine = true;
+        config.bg_removal.msmv.maxk = 9;
+        let cmd = generate_command(&config);
+        assert!(cmd.contains("--msmv-refine"), "got: {}", cmd);
+        assert!(cmd.contains("--msmv-maxk 9"), "got: {}", cmd);
+        // A default param is not emitted (only the refine flag + changed knobs).
+        assert!(!cmd.contains("--msmv-radius"), "got: {}", cmd);
     }
 
     #[test]

--- a/crates/qsmxt-config/src/config.rs
+++ b/crates/qsmxt-config/src/config.rs
@@ -140,10 +140,13 @@ pub fn enforce_separation_dependencies(config: &mut PipelineConfig) {
             // Fits the multi-echo magnitude signal directly; no relaxometry maps needed.
             SeparationAlgorithm::Decompose => {}
             // R2'-based methods: need R2' (unless a custom R2' map is supplied).
+            // SUSEP-Net consumes [QSM, R2', local field] → [χ+, χ−], so it needs R2' too.
             SeparationAlgorithm::ChiSepIlsqr
             | SeparationAlgorithm::ChiSepMedi
             | SeparationAlgorithm::WaveSep
-            | SeparationAlgorithm::HcChisep => {
+            | SeparationAlgorithm::HcChisep
+            | SeparationAlgorithm::SusepNet
+            | SeparationAlgorithm::ChiSepNet => {
                 if config.separation.custom_r2prime_tool.is_none() {
                     config.pipeline.do_r2primemap = true;
                 }
@@ -172,6 +175,12 @@ param_config!(ResharpConfig from qsm_core::bgremove::ResharpParams {
 });
 param_config!(HarperellaConfig from qsm_core::bgremove::HarperellaParams {
     radius: f64, max_iter: usize, tol: f64
+});
+// mSMV boundary-shadow refinement. Only radius/maxk are user knobs here; b0/te are
+// runtime scan parameters (overridden from ScanMetadata by qsm-core), and prefilter is
+// forced off by the dispatcher in refinement mode.
+param_config!(MsmvConfig from qsm_core::bgremove::MsmvParams {
+    radius: f64, maxk: usize
 });
 param_config!(BetConfig from qsm_core::bet::BetParams {
     fractional_intensity: f64, smoothness: f64, gradient_threshold: f64,
@@ -449,6 +458,11 @@ pub struct BgRemovalConfig {
     pub resharp: ResharpConfig,
     pub harperella: HarperellaConfig,
     pub iharperella: HarperellaConfig,
+    pub msmv: MsmvConfig,
+    /// Apply mSMV boundary-shadow refinement (Roberts 2024) as a post-step on top of the
+    /// selected primary background-field removal. mSMV is a refinement, not a standalone
+    /// primary remover, so this is how it's wired into the pipeline.
+    pub msmv_refine: bool,
 }
 impl Default for BgRemovalConfig {
     fn default() -> Self {
@@ -458,6 +472,7 @@ impl Default for BgRemovalConfig {
             lbv: LbvConfig::default(), ismv: IsmvConfig::default(),
             sharp: SharpConfig::default(), resharp: ResharpConfig::default(),
             harperella: HarperellaConfig::default(), iharperella: HarperellaConfig::default(),
+            msmv: MsmvConfig::default(), msmv_refine: false,
         }
     }
 }
@@ -547,9 +562,13 @@ impl PipelineConfig {
 fn prune_to_selected_algorithm(root: &mut toml::value::Table, section: &str) {
     let Some(toml::Value::Table(sub)) = root.get_mut(section) else { return };
     let Some(selected) = sub.get("algorithm").and_then(|v| v.as_str()).map(str::to_owned) else { return };
+    // mSMV is a boundary-shadow refinement layered on top of the primary BFR, not a primary
+    // alternative — keep its params table whenever the refinement is enabled.
+    let keep_msmv = sub.get("msmv_refine").and_then(|v| v.as_bool()).unwrap_or(false);
     let to_remove: Vec<String> = sub
         .iter()
-        .filter(|(k, v)| k.as_str() != "algorithm" && v.is_table() && k.as_str() != selected)
+        .filter(|(k, v)| k.as_str() != "algorithm" && v.is_table() && k.as_str() != selected
+            && !(keep_msmv && k.as_str() == "msmv"))
         .map(|(k, _)| k.clone())
         .collect();
     for k in &to_remove {

--- a/crates/qsmxt-config/src/enums.rs
+++ b/crates/qsmxt-config/src/enums.rs
@@ -9,6 +9,15 @@ pub enum QsmAlgorithm {
     #[serde(rename = "fansi-tgv")] FansiTgv,
     L1qsm, Whqsm, Hdqsm,
     #[serde(rename = "amp-pe")] AmpPe,
+    // Deep-learning dipole inversions (require qsm-core's `onnx` feature + downloadable weights).
+    Xqsm, Qsmnet,
+    #[serde(rename = "qsmnet-plus")] QsmnetPlus,
+    Autoqsm, Qsmgan, Ir2qsm, Lpcnn,
+    #[serde(rename = "modl-qsm")] ModlQsm,
+    Nextqsm,
+    // End-to-end DL reconstructions from wrapped phase (like TGV: no separate BFR/unwrap).
+    Iqsm,
+    #[serde(rename = "iqsm-plus")] IqsmPlus,
 }
 impl fmt::Display for QsmAlgorithm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -19,6 +28,11 @@ impl fmt::Display for QsmAlgorithm {
             Self::Ndi => "ndi", Self::Fansi => "fansi", Self::FansiTgv => "fansi-tgv",
             Self::L1qsm => "l1qsm", Self::Whqsm => "whqsm", Self::Hdqsm => "hdqsm",
             Self::AmpPe => "amp-pe",
+            Self::Xqsm => "xqsm", Self::Qsmnet => "qsmnet",
+            Self::QsmnetPlus => "qsmnet-plus", Self::Autoqsm => "autoqsm",
+            Self::Qsmgan => "qsmgan", Self::Ir2qsm => "ir2qsm", Self::Lpcnn => "lpcnn",
+            Self::ModlQsm => "modl-qsm", Self::Nextqsm => "nextqsm",
+            Self::Iqsm => "iqsm", Self::IqsmPlus => "iqsm-plus",
         })
     }
 }
@@ -31,6 +45,9 @@ pub enum SeparationAlgorithm {
     #[serde(rename = "chi-sep-medi")] ChiSepMedi,
     #[serde(rename = "wavesep")] WaveSep,
     #[serde(rename = "hc-chisep")] HcChisep,
+    // Deep-learning source separation (qsm-core `onnx` feature + downloadable weights).
+    #[serde(rename = "susep-net")] SusepNet,
+    #[serde(rename = "chi-sepnet")] ChiSepNet,
 }
 impl fmt::Display for SeparationAlgorithm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -38,6 +55,7 @@ impl fmt::Display for SeparationAlgorithm {
             Self::R2starQsm => "r2star-qsm", Self::Decompose => "decompose",
             Self::ChiSepIlsqr => "chi-sep-ilsqr", Self::ChiSepMedi => "chi-sep-medi",
             Self::WaveSep => "wavesep", Self::HcChisep => "hc-chisep",
+            Self::SusepNet => "susep-net", Self::ChiSepNet => "chi-sepnet",
         })
     }
 }
@@ -55,6 +73,12 @@ impl fmt::Display for UnwrappingAlgorithm {
 #[serde(rename_all = "lowercase")]
 pub enum BfAlgorithm {
     Vsharp, Pdf, Lbv, Ismv, Sharp, Resharp, Harperella, Iharperella,
+    // Deep-learning background removal (qsm-core `onnx` feature + downloadable weights).
+    Bfrnet,
+    // iQFM: joint DL unwrap + background removal from wrapped phase → local field.
+    // A "field preparation" choice occupying the BG-removal slot (input is phase, handled
+    // specially by the runner), not a total-field→local BFR.
+    Iqfm,
 }
 impl fmt::Display for BfAlgorithm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -62,6 +86,7 @@ impl fmt::Display for BfAlgorithm {
             Self::Vsharp => "vsharp", Self::Pdf => "pdf", Self::Lbv => "lbv",
             Self::Ismv => "ismv", Self::Sharp => "sharp", Self::Resharp => "resharp",
             Self::Harperella => "harperella", Self::Iharperella => "iharperella",
+            Self::Bfrnet => "bfrnet", Self::Iqfm => "iqfm",
         })
     }
 }

--- a/crates/qsmxt-config/src/methods.rs
+++ b/crates/qsmxt-config/src/methods.rs
@@ -162,6 +162,81 @@ const CITE_IHARPERELLA: Citation = Citation {
     text: "Li, W., Wu, B., Liu, C. (2015). \"iHARPERELLA: an improved method for integrated 3D phase unwrapping and background phase removal.\" *Proc. ISMRM* 23, p.3313.",
 };
 
+const CITE_XQSM: Citation = Citation {
+    key: "gao2021xqsm",
+    text: "Gao, Y., et al. (2021). \"xQSM: quantitative susceptibility mapping with octave convolutional and noise-regularized neural networks.\" *NMR in Biomedicine*, 34(3):e4461. https://doi.org/10.1002/nbm.4461",
+};
+
+const CITE_QSMNET: Citation = Citation {
+    key: "yoon2018qsmnet",
+    text: "Yoon, J., et al. (2018). \"Quantitative susceptibility mapping using deep neural network: QSMnet.\" *NeuroImage*, 179:199-206. https://doi.org/10.1016/j.neuroimage.2018.06.030",
+};
+
+const CITE_QSMNET_PLUS: Citation = Citation {
+    key: "jung2020qsmnetplus",
+    text: "Jung, W., et al. (2020). \"Exploring linearity of deep neural network trained QSM: QSMnet+.\" *NeuroImage*, 211:116579. https://doi.org/10.1016/j.neuroimage.2020.116579",
+};
+
+const CITE_AUTOQSM: Citation = Citation {
+    key: "wei2019autoqsm",
+    text: "Wei, H., et al. (2019). \"Learning-based single-step quantitative susceptibility mapping reconstruction without brain extraction (AutoQSM).\" *NeuroImage*, 202:116064. https://doi.org/10.1016/j.neuroimage.2019.116064",
+};
+
+const CITE_BFRNET: Citation = Citation {
+    key: "zhang2023bfrnet",
+    text: "Zhang, J., et al. (2023). \"BFRnet: A deep learning-based MR background field removal method for QSM.\" *Magnetic Resonance Imaging*, 100:15-24. https://github.com/sunhongfu/BFRnet",
+};
+
+const CITE_SUSEPNET: Citation = Citation {
+    key: "li2025susepnet",
+    text: "Li, Z., Gao, Y., Sun, H., et al. (2025). \"SUSEP-Net: deep learning susceptibility source separation.\" arXiv:2506.13293.",
+};
+
+const CITE_CHISEPNET: Citation = Citation {
+    key: "kim2025chisepnet",
+    text: "Kim, M., et al. (SNU-LIST). \"χ-sepnet: deep learning χ-separation network.\" https://github.com/SNU-LIST/chi-separation",
+};
+
+const CITE_QSMGAN: Citation = Citation {
+    key: "chen2020qsmgan",
+    text: "Chen, Y., et al. (2020). \"QSMGAN: improved quantitative susceptibility mapping using 3D generative adversarial networks with increased receptive field.\" *NeuroImage*, 207:116389. https://doi.org/10.1016/j.neuroimage.2019.116389",
+};
+
+const CITE_LPCNN: Citation = Citation {
+    key: "lai2020lpcnn",
+    text: "Lai, K.-W., et al. (2020). \"Learned proximal networks for quantitative susceptibility mapping (LPCNN).\" *MICCAI 2020*, LNCS 12262:125-135. https://doi.org/10.1007/978-3-030-59713-9_13",
+};
+
+const CITE_IR2QSM: Citation = Citation {
+    key: "li2025ir2qsm",
+    text: "Li, M., et al. (2025). \"IR2QSM: quantitative susceptibility mapping via deep neural networks with iterative reverse concatenations and recurrent modules.\" *Medical Physics*. https://doi.org/10.1002/mp.17747",
+};
+
+const CITE_MODLQSM: Citation = Citation {
+    key: "feng2021modlqsm",
+    text: "Feng, R., et al. (2021). \"MoDL-QSM: model-based deep learning for quantitative susceptibility mapping.\" *NeuroImage*, 240:118376. https://doi.org/10.1016/j.neuroimage.2021.118376",
+};
+
+const CITE_NEXTQSM: Citation = Citation {
+    key: "cognolato2023nextqsm",
+    text: "Cognolato, F., et al. (2023). \"NeXtQSM — a complete deep learning pipeline for data-consistent quantitative susceptibility mapping trained with hybrid data.\" *NeuroImage*, 271:119729. https://doi.org/10.1016/j.neuroimage.2022.119729",
+};
+
+const CITE_IQSM: Citation = Citation {
+    key: "gao2022iqsm",
+    text: "Gao, Y., et al. (2022). \"Instant tissue field and magnetic susceptibility mapping from MRI raw phase using Laplacian-enhanced deep neural networks (iQSM/iQFM).\" *NeuroImage*, 259:119410. https://doi.org/10.1016/j.neuroimage.2022.119410",
+};
+
+const CITE_IQSM_PLUS: Citation = Citation {
+    key: "gao2024iqsmplus",
+    text: "Gao, Y., et al. (2024). \"Plug-and-play latent feature editing for orientation-adaptive quantitative susceptibility mapping (iQSM+).\" *Medical Image Analysis*, 94:103160. https://doi.org/10.1016/j.media.2024.103160",
+};
+
+const CITE_MSMV: Citation = Citation {
+    key: "roberts2024",
+    text: "Roberts, A.G., et al. (2024). \"Maximum spherical mean value (mSMV) filtering for whole-brain quantitative susceptibility mapping.\" *Magnetic Resonance in Medicine*, 91(4):1586-1597. https://doi.org/10.1002/mrm.29963",
+};
+
 const CITE_CLEARSWI: Citation = Citation {
     key: "eckstein2024",
     text: "Eckstein, K., et al. (2024). \"CLEAR-SWI: Computational Efficient T2* Weighted Imaging.\" *Proc. ISMRM*.",
@@ -265,9 +340,20 @@ pub fn generate_methods_for(config: &PipelineConfig, tool: &str) -> String {
                         BfAlgorithm::Resharp => ("RESHARP", &CITE_RESHARP),
                         BfAlgorithm::Harperella => ("HARPERELLA", &CITE_HARPERELLA),
                         BfAlgorithm::Iharperella => ("iHARPERELLA", &CITE_IHARPERELLA),
+                        BfAlgorithm::Bfrnet => ("BFRnet (deep-learning background removal)", &CITE_BFRNET),
+                        BfAlgorithm::Iqfm => ("iQFM (deep-learning joint unwrapping + background removal)", &CITE_IQSM),
                     };
                     sentences.push(format!("Background field removal was performed using {} ({}).", name, cite_inline(cite)));
                     add_citation(&mut citations, cite);
+
+                    // Optional mSMV boundary-shadow refinement layered on the primary BFR.
+                    if config.bg_removal.msmv_refine {
+                        sentences.push(format!(
+                            "Residual boundary-field shadows were then removed with maximum spherical mean value (mSMV) filtering ({}).",
+                            cite_inline(&CITE_MSMV),
+                        ));
+                        add_citation(&mut citations, &CITE_MSMV);
+                    }
                 }
 
                 // Dipole inversion
@@ -535,6 +621,17 @@ fn inversion_name_cite(alg: QsmAlgorithm) -> (&'static str, &'static Citation) {
         QsmAlgorithm::Whqsm => ("WH-QSM (Weak-Harmonic)", &CITE_WHQSM),
         QsmAlgorithm::Hdqsm => ("HD-QSM (Hybrid Data Fidelity)", &CITE_HDQSM),
         QsmAlgorithm::AmpPe => ("AMP-PE (Approximate Message Passing with Parameter Estimation)", &CITE_AMPPE),
+        QsmAlgorithm::Xqsm => ("xQSM (deep-learning dipole inversion)", &CITE_XQSM),
+        QsmAlgorithm::Qsmnet => ("QSMnet (deep-learning dipole inversion)", &CITE_QSMNET),
+        QsmAlgorithm::QsmnetPlus => ("QSMnet+ (deep-learning dipole inversion)", &CITE_QSMNET_PLUS),
+        QsmAlgorithm::Autoqsm => ("AutoQSM (single-step deep-learning reconstruction)", &CITE_AUTOQSM),
+        QsmAlgorithm::Qsmgan => ("QSMGAN (GAN-refined deep-learning dipole inversion)", &CITE_QSMGAN),
+        QsmAlgorithm::Ir2qsm => ("IR2QSM (unrolled deep-learning dipole inversion)", &CITE_IR2QSM),
+        QsmAlgorithm::Lpcnn => ("LPCNN (learned-proximal deep-learning dipole inversion)", &CITE_LPCNN),
+        QsmAlgorithm::ModlQsm => ("MoDL-QSM (model-based deep-learning dipole inversion)", &CITE_MODLQSM),
+        QsmAlgorithm::Nextqsm => ("NeXtQSM (single-step deep-learning reconstruction)", &CITE_NEXTQSM),
+        QsmAlgorithm::Iqsm => ("iQSM (end-to-end deep-learning reconstruction from phase)", &CITE_IQSM),
+        QsmAlgorithm::IqsmPlus => ("iQSM+ (orientation-adaptive end-to-end deep-learning reconstruction)", &CITE_IQSM_PLUS),
         QsmAlgorithm::Tgv | QsmAlgorithm::Qsmart => ("iLSQR", &CITE_ILSQR),
     }
 }
@@ -547,6 +644,8 @@ fn separation_name_cite(alg: SeparationAlgorithm) -> (&'static str, &'static Cit
         SeparationAlgorithm::ChiSepMedi => ("χ-separation (MEDI)", &CITE_CHISEP),
         SeparationAlgorithm::WaveSep => ("WaveSep", &CITE_WAVESEP),
         SeparationAlgorithm::HcChisep => ("hollow-cylinder χ-separation (HC-ChiSep)", &CITE_HCCHISEP),
+        SeparationAlgorithm::SusepNet => ("SUSEP-Net (deep-learning source separation)", &CITE_SUSEPNET),
+        SeparationAlgorithm::ChiSepNet => ("χ-sepnet (deep-learning source separation)", &CITE_CHISEPNET),
     }
 }
 
@@ -578,6 +677,21 @@ fn cite_inline(cite: &Citation) -> &'static str {
         "sun2014" => "Sun & Wilman, 2014",
         "li2014" => "Li et al., 2014",
         "li2015iharp" => "Li et al., 2015",
+        "roberts2024" => "Roberts et al., 2024",
+        "gao2021xqsm" => "Gao et al., 2021",
+        "yoon2018qsmnet" => "Yoon et al., 2018",
+        "jung2020qsmnetplus" => "Jung et al., 2020",
+        "wei2019autoqsm" => "Wei et al., 2019",
+        "zhang2023bfrnet" => "Zhang et al., 2023",
+        "li2025susepnet" => "Li et al., 2025",
+        "kim2025chisepnet" => "Kim et al. (SNU-LIST)",
+        "chen2020qsmgan" => "Chen et al., 2020",
+        "lai2020lpcnn" => "Lai et al., 2020",
+        "li2025ir2qsm" => "Li et al., 2025",
+        "feng2021modlqsm" => "Feng et al., 2021",
+        "cognolato2023nextqsm" => "Cognolato et al., 2023",
+        "gao2022iqsm" => "Gao et al., 2022",
+        "gao2024iqsmplus" => "Gao et al., 2024",
         "eckstein2021phd" => "Eckstein, 2021",
         _ => cite.key,
     }
@@ -742,12 +856,27 @@ mod tests {
             (BfAlgorithm::Resharp, "RESHARP"),
             (BfAlgorithm::Harperella, "HARPERELLA"),
             (BfAlgorithm::Iharperella, "iHARPERELLA"),
+            (BfAlgorithm::Bfrnet, "BFRnet"),
+            (BfAlgorithm::Iqfm, "iQFM"),
         ] {
             let mut c = PipelineConfig::default();
             c.bg_removal.algorithm = alg;
             let out = generate_methods(&c);
             assert!(out.contains(expected), "missing {} for {:?}", expected, alg);
         }
+    }
+
+    #[test]
+    fn test_msmv_refine_methods() {
+        let mut config = PipelineConfig::default();
+        // Off by default: no mSMV sentence.
+        assert!(!generate_methods(&config).contains("mSMV"));
+        // On: the primary BFR is still described, followed by the mSMV refinement.
+        config.bg_removal.msmv_refine = true;
+        let out = generate_methods(&config);
+        assert!(out.contains("V-SHARP"), "primary BFR still described: {}", out);
+        assert!(out.contains("mSMV"), "mSMV refinement described: {}", out);
+        assert!(out.contains("Roberts et al., 2024"));
     }
 
     #[test]
@@ -1100,6 +1229,17 @@ mod tests {
             (QsmAlgorithm::Whqsm, "WH-QSM"),
             (QsmAlgorithm::Hdqsm, "HD-QSM"),
             (QsmAlgorithm::AmpPe, "AMP-PE"),
+            (QsmAlgorithm::Xqsm, "xQSM"),
+            (QsmAlgorithm::Qsmnet, "QSMnet"),
+            (QsmAlgorithm::QsmnetPlus, "QSMnet+"),
+            (QsmAlgorithm::Autoqsm, "AutoQSM"),
+            (QsmAlgorithm::Qsmgan, "QSMGAN"),
+            (QsmAlgorithm::Ir2qsm, "IR2QSM"),
+            (QsmAlgorithm::Lpcnn, "LPCNN"),
+            (QsmAlgorithm::ModlQsm, "MoDL-QSM"),
+            (QsmAlgorithm::Nextqsm, "NeXtQSM"),
+            (QsmAlgorithm::Iqsm, "iQSM"),
+            (QsmAlgorithm::IqsmPlus, "iQSM+"),
         ] {
             let mut c = PipelineConfig::default();
             c.inversion.algorithm = alg;

--- a/crates/qsmxt-config/tests/param_coverage.rs
+++ b/crates/qsmxt-config/tests/param_coverage.rs
@@ -90,6 +90,9 @@ fn qsmxt_config_covers_all_qsm_core_params() {
     cover!(q::bgremove::SharpParams => c::SharpConfig);
     cover!(q::bgremove::ResharpParams => c::ResharpConfig);
     cover!(q::bgremove::HarperellaParams => c::HarperellaConfig);
+    // mSMV: b0/te are runtime scan parameters; prefilter is a mode flag (forced off in
+    // refinement mode by the dispatcher), not a user knob in the pipeline.
+    cover!(q::bgremove::MsmvParams => c::MsmvConfig, ignore: ["b0", "te", "prefilter"]);
 
     // Masking / field mapping / misc
     cover!(q::bet::BetParams => c::BetConfig);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -699,6 +699,19 @@ pub struct IharperellaParamArgs {
 }
 
 #[derive(Args, Debug, Default, Clone)]
+pub struct MsmvParamArgs {
+    /// Apply mSMV boundary-shadow refinement (Roberts 2024) on top of the primary BFR
+    #[arg(long)]
+    pub msmv_refine: bool,
+    /// mSMV SMV kernel radius in mm
+    #[arg(long)]
+    pub msmv_radius: Option<f64>,
+    /// mSMV maximum boundary-correction iterations
+    #[arg(long)]
+    pub msmv_maxk: Option<usize>,
+}
+
+#[derive(Args, Debug, Default, Clone)]
 pub struct RomeoParamArgs {
     /// ROMEO: disable phase gradient coherence weights
     #[arg(long)]
@@ -882,6 +895,8 @@ pub struct RunArgs {
     pub harperella_params: HarperellaParamArgs,
     #[command(flatten)]
     pub iharperella_params: IharperellaParamArgs,
+    #[command(flatten)]
+    pub msmv_params: MsmvParamArgs,
     #[command(flatten)]
     pub romeo_params: RomeoParamArgs,
     #[command(flatten)]
@@ -1255,6 +1270,16 @@ pub enum BgremoveCommand {
     Harperella(BgremoveHarperellaArgs),
     /// Improved HARPERELLA (iHARPERELLA)
     Iharperella(BgremoveIharperellaArgs),
+    /// Maximum Spherical Mean Value (mSMV) boundary-shadow removal
+    Msmv(BgremoveMsmvArgs),
+    /// BFRnet deep-learning background removal (weights downloaded on first use)
+    Bfrnet(BgremoveBfrnetArgs),
+}
+
+#[derive(Parser, Debug)]
+pub struct BgremoveBfrnetArgs {
+    #[command(flatten)]
+    pub common: BgremoveCommonArgs,
 }
 
 #[derive(Parser, Debug)]
@@ -1333,6 +1358,28 @@ pub struct BgremoveResharpArgs {
     /// Maximum CG iterations
     #[arg(long)]
     pub max_iter: Option<usize>,
+}
+
+#[derive(Parser, Debug)]
+pub struct BgremoveMsmvArgs {
+    #[command(flatten)]
+    pub common: BgremoveCommonArgs,
+    /// SMV prefilter kernel radius in mm
+    #[arg(long)]
+    pub radius: Option<f64>,
+    /// Maximum boundary-correction iterations
+    #[arg(long)]
+    pub maxk: Option<usize>,
+    /// B0 field strength (T) — sets the radian shadow-threshold cap
+    #[arg(long)]
+    pub field_strength: Option<f64>,
+    /// Echo time (s) for the ppm↔radian conversion
+    #[arg(long)]
+    pub te: Option<f64>,
+    /// Refinement mode: skip the SMV prefilter and treat the input as an already-local
+    /// field from a primary BFR (only the boundary-shadow correction is applied)
+    #[arg(long)]
+    pub refine: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -1451,6 +1498,35 @@ pub enum InvertCommand {
     Hdqsm(InvertHdqsmArgs),
     /// AMP-PE (Approximate Message Passing with Parameter Estimation)
     AmpPe(InvertAmpPeArgs),
+    /// xQSM deep-learning dipole inversion (weights downloaded on first use)
+    Xqsm(InvertDlArgs),
+    /// QSMnet deep-learning dipole inversion (weights downloaded on first use)
+    Qsmnet(InvertDlArgs),
+    /// QSMnet+ deep-learning dipole inversion (weights downloaded on first use)
+    QsmnetPlus(InvertDlArgs),
+    /// AutoQSM single-step reconstruction — input is the TOTAL field (weights downloaded on first use)
+    Autoqsm(InvertDlArgs),
+    /// QSMGAN deep-learning dipole inversion (weights downloaded on first use)
+    Qsmgan(InvertDlArgs),
+    /// IR2QSM deep-learning dipole inversion (weights downloaded on first use)
+    Ir2qsm(InvertDlArgs),
+    /// LPCNN deep-learning dipole inversion (weights downloaded on first use)
+    Lpcnn(InvertDlArgs),
+    /// MoDL-QSM deep-learning dipole inversion → χ33/STI component (weights downloaded on first use)
+    ModlQsm(InvertDlArgs),
+    /// NeXtQSM single-step reconstruction — input is the TOTAL field (weights downloaded on first use)
+    Nextqsm(InvertDlArgs),
+}
+
+/// Args for the deep-learning dipole inversions. They have no tunable parameters;
+/// weights are fetched on first use. `--field-strength` feeds the scan metadata.
+#[derive(Parser, Debug)]
+pub struct InvertDlArgs {
+    #[command(flatten)]
+    pub common: InvertCommonArgs,
+    /// B0 field strength in Tesla (scan metadata)
+    #[arg(long, default_value_t = 3.0)]
+    pub field_strength: f64,
 }
 
 #[derive(Parser, Debug)]
@@ -1902,6 +1978,11 @@ pub enum SeparationAlgorithmArg {
     Wavesep,
     /// Hollow-cylinder χ-separation (Stewart 2026) — QSM + R2' + multi-echo magnitude
     HcChisep,
+    /// SUSEP-Net deep-learning separation — QSM + R2' + local field (weights downloaded on first use)
+    SusepNet,
+    /// χ-sepnet deep-learning separation — QSM + R2' + local field (weights downloaded on first use)
+    #[value(name = "chi-sepnet")]
+    ChiSepNet,
 }
 
 /// Inputs shared by every chi-separation method.
@@ -1938,6 +2019,23 @@ pub enum SeparateCommand {
     Wavesep(SeparateWavesepArgs),
     /// Hollow-cylinder χ-separation (Stewart 2026) — QSM + R2' + multi-echo magnitude
     HcChisep(SeparateHcChisepArgs),
+    /// SUSEP-Net deep-learning separation — QSM + R2' + local field (weights downloaded on first use)
+    SusepNet(SeparateSusepNetArgs),
+    /// χ-sepnet deep-learning separation — QSM + R2' + local field (weights downloaded on first use)
+    #[command(name = "chi-sepnet")]
+    ChiSepNet(SeparateSusepNetArgs),
+}
+
+#[derive(Parser, Debug)]
+pub struct SeparateSusepNetArgs {
+    #[command(flatten)]
+    pub common: SeparateCommonArgs,
+    /// Local (tissue) field NIfTI in ppm
+    #[arg(long)]
+    pub local_field: PathBuf,
+    /// R2' map NIfTI in Hz
+    #[arg(long)]
+    pub r2prime: PathBuf,
 }
 
 #[derive(Parser, Debug)]
@@ -2360,6 +2458,10 @@ pub struct QualityMapArgs {
 pub enum QsmAlgorithmArg {
     Rts, Tv, Tkd, Tsvd, Tgv, Tikhonov, Nltv, Medi, Tfi, Ilsqr, Qsmart,
     Ndi, Fansi, FansiTgv, L1qsm, Whqsm, Hdqsm, AmpPe,
+    // Deep-learning dipole inversions (weights downloaded on first use).
+    Xqsm, Qsmnet, QsmnetPlus, Autoqsm, Qsmgan, Ir2qsm, Lpcnn, ModlQsm, Nextqsm,
+    // End-to-end DL reconstructions from wrapped phase (no separate unwrap/BFR).
+    Iqsm, IqsmPlus,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq)]
@@ -2370,6 +2472,10 @@ pub enum UnwrapAlgorithmArg {
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq)]
 pub enum BfAlgorithmArg {
     Vsharp, Pdf, Lbv, Ismv, Sharp, Resharp, Harperella, Iharperella,
+    /// BFRnet deep-learning background removal (weights downloaded on first use)
+    Bfrnet,
+    /// iQFM deep-learning joint unwrapping + background removal from phase (weights downloaded on first use)
+    Iqfm,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq)]

--- a/src/commands/bgremove.rs
+++ b/src/commands/bgremove.rs
@@ -135,6 +135,50 @@ pub fn execute(cmd: BgremoveCommand) -> crate::Result<()> {
             );
             (c, (lf, field_nifti), em)
         }
+        BgremoveCommand::Msmv(args) => {
+            let c = args.common;
+            let field_nifti = load_nifti(&c.input)?;
+            let (mask, _) = load_mask(&c.mask)?;
+            let (nx, ny, nz) = field_nifti.dims;
+            let (vsx, vsy, vsz) = field_nifti.voxel_size;
+            let grid = qsm_core::Grid::new(nx, ny, nz, vsx, vsy, vsz);
+            info!("Background removal (mSMV, {}x{}x{})", grid.nx(), grid.ny(), grid.nz());
+
+            let d = qsm_core::bgremove::MsmvParams::default();
+            let params = qsm_core::bgremove::MsmvParams {
+                radius: args.radius.unwrap_or(d.radius),
+                maxk: args.maxk.unwrap_or(d.maxk),
+                b0: args.field_strength.unwrap_or(d.b0),
+                te: args.te.unwrap_or(d.te),
+                // Standalone (prefilter) by default; --refine skips the SMV prefilter to
+                // treat the input as an already-local field from a primary BFR.
+                prefilter: !args.refine,
+            };
+            // mSMV preserves the brain edge (no erosion): it returns the mask unchanged.
+            let (lf, em) = qsm_core::bgremove::msmv(
+                &field_nifti.data, &mask, &grid, &params, |_, _| {},
+            );
+            (c, (lf, field_nifti), em)
+        }
+        BgremoveCommand::Bfrnet(args) => {
+            let c = args.common;
+            let field_nifti = load_nifti(&c.input)?;
+            let (mask, _) = load_mask(&c.mask)?;
+            let (nx, ny, nz) = field_nifti.dims;
+            let (vsx, vsy, vsz) = field_nifti.voxel_size;
+            let grid = qsm_core::Grid::new(nx, ny, nz, vsx, vsy, vsz);
+            info!("Background removal (BFRnet, {}x{}x{})", grid.nx(), grid.ny(), grid.nz());
+
+            // Fetch the ONNX weights (cached under $QSM_MODEL_DIR / the download cache).
+            let spec = qsm_core::models::find_model("bfrnet")
+                .ok_or_else(|| crate::error::QsmxtError::Config("bfrnet not in model registry".into()))?;
+            let weights = qsm_core::models::primary_weight_bytes(spec)
+                .map_err(|e| crate::error::QsmxtError::Config(format!("BFRnet weights: {}", e)))?;
+            let lf = qsm_core::bgremove::bfrnet(&field_nifti.data, &mask, &grid, &weights)
+                .map_err(|e| crate::error::QsmxtError::Config(format!("BFRnet: {}", e)))?;
+            // BFRnet preserves the brain edge (no erosion): mask returned unchanged.
+            (c, (lf, field_nifti), mask)
+        }
         BgremoveCommand::Harperella(args) => {
             let phase_nifti = load_nifti(&args.input)?;
             let (mask, _) = load_mask(&args.mask)?;

--- a/src/commands/invert.rs
+++ b/src/commands/invert.rs
@@ -1,6 +1,31 @@
 use log::{info, warn};
 use super::common::{load_nifti, load_mask, save_nifti};
-use crate::cli::InvertCommand;
+use crate::cli::{InvertCommand, InvertCommonArgs};
+
+/// Run a deep-learning dipole inversion through qsm-core's pipeline dispatcher (the DL models
+/// are not exposed as standalone functions). Weights are downloaded on first use. AutoQSM is
+/// single-step and expects the TOTAL field as input; the others take a local (tissue) field.
+fn run_dl_inversion(
+    c: InvertCommonArgs, field_strength: f64,
+    algorithm: qsm_core::pipeline::InversionAlgorithm, name: &str,
+) -> crate::Result<(InvertCommonArgs, (Vec<f64>, qsm_core::io::NiftiData))> {
+    let field_nifti = load_nifti(&c.input)?;
+    let (mask, _) = load_mask(&c.mask)?;
+    let (nx, ny, nz) = field_nifti.dims;
+    info!("Dipole inversion ({}, {}x{}x{})", name, nx, ny, nz);
+    let metadata = qsm_core::pipeline::ScanMetadata {
+        dims: field_nifti.dims,
+        voxel_size: field_nifti.voxel_size,
+        echo_times: vec![],
+        field_strength,
+        b0_direction: (c.b0_direction[0], c.b0_direction[1], c.b0_direction[2]),
+    };
+    let config = qsm_core::pipeline::InversionConfig { algorithm, ..Default::default() };
+    let chi = qsm_core::pipeline::run_dipole_inversion(
+        &field_nifti.data, &mask, &metadata, &config, None, &mut |_, _| {},
+    ).map_err(|e| crate::error::QsmxtError::Config(format!("{}: {}", name, e)))?;
+    Ok((c, (chi, field_nifti)))
+}
 
 pub fn execute(cmd: InvertCommand) -> crate::Result<()> {
     let (common, chi) = match cmd {
@@ -421,6 +446,24 @@ pub fn execute(cmd: InvertCommand) -> crate::Result<()> {
             );
             (c, (chi, field_nifti))
         }
+        InvertCommand::Xqsm(args) =>
+            run_dl_inversion(args.common, args.field_strength, qsm_core::pipeline::InversionAlgorithm::Xqsm, "xQSM")?,
+        InvertCommand::Qsmnet(args) =>
+            run_dl_inversion(args.common, args.field_strength, qsm_core::pipeline::InversionAlgorithm::Qsmnet, "QSMnet")?,
+        InvertCommand::QsmnetPlus(args) =>
+            run_dl_inversion(args.common, args.field_strength, qsm_core::pipeline::InversionAlgorithm::QsmnetPlus, "QSMnet+")?,
+        InvertCommand::Autoqsm(args) =>
+            run_dl_inversion(args.common, args.field_strength, qsm_core::pipeline::InversionAlgorithm::Autoqsm, "AutoQSM")?,
+        InvertCommand::Qsmgan(args) =>
+            run_dl_inversion(args.common, args.field_strength, qsm_core::pipeline::InversionAlgorithm::Qsmgan, "QSMGAN")?,
+        InvertCommand::Ir2qsm(args) =>
+            run_dl_inversion(args.common, args.field_strength, qsm_core::pipeline::InversionAlgorithm::Ir2qsm, "IR2QSM")?,
+        InvertCommand::Lpcnn(args) =>
+            run_dl_inversion(args.common, args.field_strength, qsm_core::pipeline::InversionAlgorithm::Lpcnn, "LPCNN")?,
+        InvertCommand::ModlQsm(args) =>
+            run_dl_inversion(args.common, args.field_strength, qsm_core::pipeline::InversionAlgorithm::ModlQsm, "MoDL-QSM")?,
+        InvertCommand::Nextqsm(args) =>
+            run_dl_inversion(args.common, args.field_strength, qsm_core::pipeline::InversionAlgorithm::Nextqsm, "NeXtQSM")?,
     };
 
     let (chi_data, field_nifti) = chi;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -79,6 +79,7 @@ mod integration_tests {
             resharp_params: Default::default(),
             harperella_params: Default::default(),
             iharperella_params: Default::default(),
+            msmv_params: Default::default(),
             romeo_params: Default::default(),
             swi_params: Default::default(),
             n_procs: Some(1),

--- a/src/commands/separate.rs
+++ b/src/commands/separate.rs
@@ -252,6 +252,46 @@ pub fn execute(cmd: SeparateCommand) -> crate::Result<()> {
                 .map_err(|e| QsmxtError::Config(format!("chi-separation: {}", e)))?;
             (c.output.clone(), qsm, result)
         }
+        SeparateCommand::SusepNet(args) => {
+            let c = &args.common;
+            let (qsm, mask, metadata, _) = load_common(c, &[])?;
+            info!("Chi-separation (susep-net, {}x{}x{})", qsm.dims.0, qsm.dims.1, qsm.dims.2);
+            let local_field = load_nifti(&args.local_field)?;
+            let r2prime = load_nifti(&args.r2prime)?;
+            // SUSEP-Net has no user-tunable parameters; weights download on first use.
+            let cfg = SeparationConfig {
+                algorithm: SeparationAlgorithm::SusepNet,
+                ..Default::default()
+            };
+            let inputs = SeparationInputs {
+                local_field_ppm: &local_field.data, qsm: &qsm.data, mask: &mask,
+                r2prime: Some(&r2prime.data), r2star: None,
+                magnitude_rss: None, magnitude_multi: None, se_magnitude_multi: None,
+            };
+            let result = run_separation(inputs, &metadata, &cfg, &mut |_, _| {})
+                .map_err(|e| QsmxtError::Config(format!("chi-separation: {}", e)))?;
+            (c.output.clone(), qsm, result)
+        }
+        SeparateCommand::ChiSepNet(args) => {
+            let c = &args.common;
+            let (qsm, mask, metadata, _) = load_common(c, &[])?;
+            info!("Chi-separation (chi-sepnet, {}x{}x{})", qsm.dims.0, qsm.dims.1, qsm.dims.2);
+            let local_field = load_nifti(&args.local_field)?;
+            let r2prime = load_nifti(&args.r2prime)?;
+            // χ-sepnet has no user-tunable parameters; weights download on first use.
+            let cfg = SeparationConfig {
+                algorithm: SeparationAlgorithm::ChiSepNet,
+                ..Default::default()
+            };
+            let inputs = SeparationInputs {
+                local_field_ppm: &local_field.data, qsm: &qsm.data, mask: &mask,
+                r2prime: Some(&r2prime.data), r2star: None,
+                magnitude_rss: None, magnitude_multi: None, se_magnitude_multi: None,
+            };
+            let result = run_separation(inputs, &metadata, &cfg, &mut |_, _| {})
+                .map_err(|e| QsmxtError::Config(format!("chi-separation: {}", e)))?;
+            (c.output.clone(), qsm, result)
+        }
     };
     save_result(&output, &result, &reference)?;
     Ok(())

--- a/src/pipeline/config.rs
+++ b/src/pipeline/config.rs
@@ -36,6 +36,17 @@ fn qsm_algorithm_arg_to_config(a: cli::QsmAlgorithmArg) -> QsmAlgorithm {
         cli::QsmAlgorithmArg::Whqsm => QsmAlgorithm::Whqsm,
         cli::QsmAlgorithmArg::Hdqsm => QsmAlgorithm::Hdqsm,
         cli::QsmAlgorithmArg::AmpPe => QsmAlgorithm::AmpPe,
+        cli::QsmAlgorithmArg::Xqsm => QsmAlgorithm::Xqsm,
+        cli::QsmAlgorithmArg::Qsmnet => QsmAlgorithm::Qsmnet,
+        cli::QsmAlgorithmArg::QsmnetPlus => QsmAlgorithm::QsmnetPlus,
+        cli::QsmAlgorithmArg::Autoqsm => QsmAlgorithm::Autoqsm,
+        cli::QsmAlgorithmArg::Qsmgan => QsmAlgorithm::Qsmgan,
+        cli::QsmAlgorithmArg::Ir2qsm => QsmAlgorithm::Ir2qsm,
+        cli::QsmAlgorithmArg::Lpcnn => QsmAlgorithm::Lpcnn,
+        cli::QsmAlgorithmArg::ModlQsm => QsmAlgorithm::ModlQsm,
+        cli::QsmAlgorithmArg::Nextqsm => QsmAlgorithm::Nextqsm,
+        cli::QsmAlgorithmArg::Iqsm => QsmAlgorithm::Iqsm,
+        cli::QsmAlgorithmArg::IqsmPlus => QsmAlgorithm::IqsmPlus,
     }
 }
 
@@ -47,6 +58,8 @@ fn separation_algorithm_arg_to_config(a: cli::SeparationAlgorithmArg) -> Separat
         cli::SeparationAlgorithmArg::ChiSepMedi => SeparationAlgorithm::ChiSepMedi,
         cli::SeparationAlgorithmArg::Wavesep => SeparationAlgorithm::WaveSep,
         cli::SeparationAlgorithmArg::HcChisep => SeparationAlgorithm::HcChisep,
+        cli::SeparationAlgorithmArg::SusepNet => SeparationAlgorithm::SusepNet,
+        cli::SeparationAlgorithmArg::ChiSepNet => SeparationAlgorithm::ChiSepNet,
     }
 }
 
@@ -96,6 +109,8 @@ pub fn apply_run_overrides(config: &mut PipelineConfig, args: &cli::RunArgs) {
                 cli::BfAlgorithmArg::Resharp => BfAlgorithm::Resharp,
                 cli::BfAlgorithmArg::Harperella => BfAlgorithm::Harperella,
                 cli::BfAlgorithmArg::Iharperella => BfAlgorithm::Iharperella,
+                cli::BfAlgorithmArg::Bfrnet => BfAlgorithm::Bfrnet,
+                cli::BfAlgorithmArg::Iqfm => BfAlgorithm::Iqfm,
             };
         }
 
@@ -262,6 +277,9 @@ pub fn apply_run_overrides(config: &mut PipelineConfig, args: &cli::RunArgs) {
         if let Some(v) = args.iharperella_params.iharperella_radius { config.bg_removal.iharperella.radius = v; }
         if let Some(v) = args.iharperella_params.iharperella_max_iter { config.bg_removal.iharperella.max_iter = v; }
         if let Some(v) = args.iharperella_params.iharperella_tol { config.bg_removal.iharperella.tol = v; }
+        if args.msmv_params.msmv_refine { config.bg_removal.msmv_refine = true; }
+        if let Some(v) = args.msmv_params.msmv_radius { config.bg_removal.msmv.radius = v; }
+        if let Some(v) = args.msmv_params.msmv_maxk { config.bg_removal.msmv.maxk = v; }
 
         // ── SWI ──
         if let Some(ref s) = args.swi_params.swi_hp_sigma {

--- a/src/pipeline/memory.rs
+++ b/src/pipeline/memory.rs
@@ -129,7 +129,8 @@ fn estimate_standard_pipeline(n: usize, n_echoes: usize, config: &PipelineConfig
         BfAlgorithm::Harperella => 60 * n,
         // iHARPERELLA: similar to HARPERELLA
         BfAlgorithm::Iharperella => 60 * n,
-        
+        // BFRnet / iQFM: ONNX U-Net activations dominate; padded field + network working set
+        BfAlgorithm::Bfrnet | BfAlgorithm::Iqfm => 120 * n,
     };
 
     // Dipole inversion
@@ -169,6 +170,16 @@ fn estimate_standard_pipeline(n: usize, n_echoes: usize, config: &PipelineConfig
         QsmAlgorithm::Hdqsm => 120 * n,
         // AMP-PE: GAMP over complex wavelet coefficients + padded FFT workspace
         QsmAlgorithm::AmpPe => 260 * n,
+        // Deep-learning inversions: ONNX U-Net activations dominate. QSMnet/QSMnet+ are the
+        // heaviest (deeper 3D U-Net, /16 padding); xQSM/AutoQSM are lighter patch/octave nets.
+        QsmAlgorithm::Qsmnet | QsmAlgorithm::QsmnetPlus => 200 * n,
+        QsmAlgorithm::Xqsm | QsmAlgorithm::Autoqsm => 120 * n,
+        // Other DL nets: unrolled/patch/single-step U-Nets. NeXtQSM (two U-Nets + unroll)
+        // and iQSM/iQSM+ (per-echo passes) are the heaviest; the rest are moderate.
+        QsmAlgorithm::Nextqsm => 220 * n,
+        QsmAlgorithm::Iqsm | QsmAlgorithm::IqsmPlus => 200 * n,
+        QsmAlgorithm::Qsmgan | QsmAlgorithm::Ir2qsm
+        | QsmAlgorithm::Lpcnn | QsmAlgorithm::ModlQsm => 140 * n,
     };
 
     // Peak is the maximum across the three sequential stages

--- a/src/pipeline/runner.rs
+++ b/src/pipeline/runner.rs
@@ -243,7 +243,13 @@ pub fn run_pipeline_cached(
 
     if config.pipeline.do_qsm {
         let field_path = output.field_ppm_path(&qsm_run.key);
-        let need_field = !matches!(config.inversion.algorithm, QsmAlgorithm::Tgv if meta.n_echoes == 1);
+        // The total (unwrapped) field is not needed when reconstruction starts from raw
+        // wrapped phase: TGV single-echo, the end-to-end iQSM/iQSM+, or iQFM field-prep
+        // (which produces the local field directly from phase).
+        let starts_from_phase = matches!(config.inversion.algorithm, QsmAlgorithm::Iqsm | QsmAlgorithm::IqsmPlus)
+            || config.bg_removal.algorithm == BfAlgorithm::Iqfm;
+        let need_field = !matches!(config.inversion.algorithm, QsmAlgorithm::Tgv if meta.n_echoes == 1)
+            && !starts_from_phase;
 
         if need_field {
             stage_unwrap(&mut ctx, &mask_path, &field_path, progress)?;
@@ -252,6 +258,7 @@ pub fn run_pipeline_cached(
         match config.inversion.algorithm {
             QsmAlgorithm::Tgv => stage_tgv(&mut ctx, &mask_path, &field_path, progress)?,
             QsmAlgorithm::Qsmart => stage_qsmart(&mut ctx, &mask_path, &field_path, progress)?,
+            QsmAlgorithm::Iqsm | QsmAlgorithm::IqsmPlus => stage_iqsm(&mut ctx, &mask_path, progress)?,
             _ => stage_standard_qsm(&mut ctx, &mask_path, &field_path, progress)?,
         }
 
@@ -905,6 +912,9 @@ fn stage_chi_separation(ctx: &mut StageContext, mask_path: &Path, progress: &dyn
         }
         SeparationAlgorithm::WaveSep => need(r2prime.is_some(), "R2'"),
         SeparationAlgorithm::HcChisep => need(r2prime.is_some(), "R2'") & need(magnitude_multi.is_some(), "multi-echo magnitude"),
+        // SUSEP-Net / χ-sepnet (deep learning) consume [QSM, R2', local field] → [χ+, χ−].
+        SeparationAlgorithm::SusepNet | SeparationAlgorithm::ChiSepNet =>
+            need(!local_field.is_empty(), "local field") & need(r2prime.is_some(), "R2'"),
     };
     if !ready {
         return Ok(());
@@ -1016,6 +1026,71 @@ fn stage_unwrap(
     let input_refs: Vec<&Path> = phase_inputs.iter().map(|p| p.as_path()).chain(std::iter::once(mask_path)).collect();
     ctx.complete_step("unwrap", Some(unwrap_alg), unwrap_params, &input_refs, vec![field_path.to_path_buf()], t)?;
     log_step_done("Phase unwrapping", t);
+    Ok(())
+}
+
+/// Per-echo phase + magnitude volumes and the phase input paths (for cache provenance).
+type PhaseEchoes = (Vec<Vec<f64>>, Vec<Vec<f64>>, Vec<PathBuf>);
+
+/// Load per-echo wrapped (offset-scaled) phase and, when present, magnitude volumes — the
+/// raw inputs for the phase-domain deep-learning models (iQSM / iQSM+ / iQFM). Returns
+/// `(phases, magnitudes, phase_input_paths)`; `magnitudes` may be empty (→ uniform weights).
+fn load_phase_echoes(ctx: &StageContext) -> crate::Result<PhaseEchoes> {
+    let mut phases = Vec::new();
+    let mut phase_inputs = Vec::new();
+    for i in 0..ctx.meta.n_echoes {
+        let p = ctx.output.phase_scaled_path(&ctx.run.key, i + 1);
+        phases.push(load_volume(&p)?);
+        phase_inputs.push(p);
+    }
+    let mut magnitudes = Vec::new();
+    for i in 0..ctx.meta.n_echoes {
+        let m = ctx.output.mag_path(&ctx.run.key, i + 1);
+        if m.exists() {
+            magnitudes.push(load_volume(&m)?);
+        }
+    }
+    Ok((phases, magnitudes, phase_inputs))
+}
+
+/// iQSM / iQSM+ end-to-end reconstruction from wrapped **phase** (joint unwrapping +
+/// background removal + dipole inversion in one network). Writes the raw susceptibility
+/// map; referencing is applied downstream by [`stage_reference`].
+fn stage_iqsm(ctx: &mut StageContext, mask_path: &Path, progress: &dyn Fn(&str)) -> crate::Result<()> {
+    let plus = matches!(ctx.config.inversion.algorithm, QsmAlgorithm::IqsmPlus);
+    let alg = if plus { "iqsm-plus" } else { "iqsm" };
+    let chi_raw_path = ctx.output.chi_raw_path(&ctx.run.key);
+    let params = serde_json::json!({
+        "echo_times": ctx.meta.echo_times,
+        "field_strength": ctx.meta.field_strength,
+        "b0_direction": [ctx.meta.b0_direction.0, ctx.meta.b0_direction.1, ctx.meta.b0_direction.2],
+    });
+    if ctx.is_cached_with_params("invert", Some(alg), &params) {
+        log::info!("Skipping {} (cached)", alg);
+        return Ok(());
+    }
+    let t = Instant::now();
+    progress("iQSM reconstruction");
+    let (phases, magnitudes, phase_inputs) = load_phase_echoes(ctx)?;
+    let mask = load_mask(mask_path)?;
+    let scan_meta = crate::pipeline::config::to_scan_metadata(
+        ctx.meta.dims, ctx.meta.voxel_size, &ctx.meta.echo_times,
+        ctx.meta.field_strength, ctx.meta.b0_direction,
+    );
+    let phase_refs: Vec<&[f64]> = phases.iter().map(|p| p.as_slice()).collect();
+    let mag_refs: Vec<&[f64]> = magnitudes.iter().map(|m| m.as_slice()).collect();
+    log::info!("{} reconstruction (end-to-end from phase)", if plus { "iQSM+" } else { "iQSM" });
+    // Referencing is done by stage_reference, so request None from the pipeline runner.
+    let chi = if plus {
+        qsm_core::pipeline::run_iqsm_plus(&phase_refs, &mag_refs, &mask, &scan_meta, qsm_core::pipeline::QsmReference::None)
+    } else {
+        qsm_core::pipeline::run_iqsm(&phase_refs, &mag_refs, &mask, &scan_meta, qsm_core::pipeline::QsmReference::None)
+    }.map_err(|e| QsmxtError::Config(format!("{}: {}", alg, e)))?;
+    save_volume(&chi_raw_path, &chi, ctx.meta)?;
+    let mut inputs: Vec<&Path> = phase_inputs.iter().map(|p| p.as_path()).collect();
+    inputs.push(mask_path);
+    ctx.complete_step("invert", Some(alg), params, &inputs, vec![chi_raw_path], t)?;
+    log_step_done(if plus { "iQSM+" } else { "iQSM" }, t);
     Ok(())
 }
 
@@ -1156,7 +1231,12 @@ fn stage_standard_qsm(
     ctx: &mut StageContext, mask_path: &Path, field_path: &Path, progress: &dyn Fn(&str),
 ) -> crate::Result<()> {
     // --- Background removal ---
-    let skip_bgremove = ctx.config.inversion.algorithm == QsmAlgorithm::Medi && ctx.config.inversion.medi.smv;
+    // MEDI+SMV, AutoQSM and NeXtQSM do their own background removal from the total field, so
+    // the standalone BFR stage is skipped and the (unwrapped) total field is fed straight in.
+    let skip_bgremove = (ctx.config.inversion.algorithm == QsmAlgorithm::Medi && ctx.config.inversion.medi.smv)
+        || matches!(ctx.config.inversion.algorithm, QsmAlgorithm::Autoqsm | QsmAlgorithm::Nextqsm);
+    // iQFM replaces unwrap+BFR: it produces the local field directly from wrapped phase.
+    let is_iqfm = ctx.config.bg_removal.algorithm == BfAlgorithm::Iqfm;
     let local_field_path = ctx.output.local_field_path(&ctx.run.key);
     let bg_mask_path = ctx.output.bg_mask_path(&ctx.run.key);
     let bf_name = format!("{}", ctx.config.bg_removal.algorithm);
@@ -1193,11 +1273,39 @@ fn stage_standard_qsm(
             "max_iter": ctx.config.bg_removal.iharperella.max_iter,
             "tol": ctx.config.bg_removal.iharperella.tol,
         }),
+        // BFRnet / iQFM (deep learning) have no user-tunable parameters; cache key is the weights.
+        BfAlgorithm::Bfrnet | BfAlgorithm::Iqfm => serde_json::json!({}),
     };
     if skip_bgremove {
-        log::info!("Skipping background removal (MEDI SMV handles it internally)");
+        log::info!("Skipping background removal (single-step inversion handles it internally)");
     }
-    if !skip_bgremove && !ctx.is_cached_with_params("bgremove", Some(&bf_name), &bf_params) {
+    // iQFM: produce the local field directly from wrapped phase (joint unwrap + BFR).
+    if is_iqfm && !skip_bgremove && !ctx.is_cached_with_params("bgremove", Some(&bf_name), &bf_params) {
+        let t = Instant::now();
+        progress("iQFM field preparation");
+        let (phases, magnitudes, phase_inputs) = load_phase_echoes(ctx)?;
+        let mask = load_mask(mask_path)?;
+        let scan_meta = crate::pipeline::config::to_scan_metadata(
+            ctx.meta.dims, ctx.meta.voxel_size, &ctx.meta.echo_times,
+            ctx.meta.field_strength, ctx.meta.b0_direction,
+        );
+        let phase_refs: Vec<&[f64]> = phases.iter().map(|p| p.as_slice()).collect();
+        let mag_refs: Vec<&[f64]> = magnitudes.iter().map(|m| m.as_slice()).collect();
+        log::info!("Background removal (iQFM, deep-learning joint unwrap+BFR)");
+        let local_field = qsm_core::pipeline::run_iqfm(&phase_refs, &mag_refs, &mask, &scan_meta)
+            .map_err(|e| QsmxtError::Config(format!("iQFM: {}", e)))?;
+        // iQFM preserves the brain edge (no erosion): reuse the brain mask.
+        save_volume(&local_field_path, &local_field, ctx.meta)?;
+        save_mask(&bg_mask_path, &mask, ctx.meta)?;
+        let mut inputs: Vec<&Path> = phase_inputs.iter().map(|p| p.as_path()).collect();
+        inputs.push(mask_path);
+        ctx.complete_step("bgremove", Some(&bf_name), bf_params.clone(), &inputs,
+            vec![local_field_path.clone(), bg_mask_path.clone()], t)?;
+        log_step_done("Background removal (iQFM)", t);
+    } else if is_iqfm {
+        log::info!("Skipping iQFM field preparation (cached)");
+    }
+    if !is_iqfm && !skip_bgremove && !ctx.is_cached_with_params("bgremove", Some(&bf_name), &bf_params) {
         let t = Instant::now();
         progress("Background field removal");
         let field_ppm = load_volume(field_path)?;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -914,6 +914,17 @@ const QSM_ALGO_HELP: &[&str] = &[
     "L1-QSM (L1 data fidelity) — https://doi.org/10.1002/mrm.29057",
     "Weak-Harmonic QSM (WH-QSM) — https://doi.org/10.1002/mrm.27483",
     "Hybrid Data Fidelity QSM (HD-QSM) — https://doi.org/10.1002/mrm.29296",
+    "xQSM deep-learning dipole inversion (weights auto-downloaded) — https://doi.org/10.1002/nbm.4461",
+    "QSMnet deep-learning dipole inversion (weights auto-downloaded) — https://doi.org/10.1016/j.neuroimage.2018.06.030",
+    "QSMnet+ deep-learning dipole inversion (weights auto-downloaded) — https://doi.org/10.1016/j.neuroimage.2020.116579",
+    "AutoQSM single-step deep-learning reconstruction, no BFR (weights auto-downloaded) — https://doi.org/10.1016/j.neuroimage.2019.116064",
+    "QSMGAN GAN-refined deep-learning dipole inversion (weights auto-downloaded) — https://doi.org/10.1016/j.neuroimage.2019.116389",
+    "IR2QSM unrolled deep-learning dipole inversion (weights auto-downloaded) — https://doi.org/10.1002/mp.17747",
+    "LPCNN learned-proximal deep-learning dipole inversion (weights auto-downloaded) — https://doi.org/10.1007/978-3-030-59713-9_13",
+    "MoDL-QSM model-based deep-learning dipole inversion, χ33/STI (weights auto-downloaded) — https://doi.org/10.1016/j.neuroimage.2021.118376",
+    "NeXtQSM single-step deep-learning reconstruction, no BFR (weights auto-downloaded) — https://doi.org/10.1016/j.neuroimage.2022.119729",
+    "iQSM end-to-end deep-learning reconstruction from phase (weights auto-downloaded) — https://doi.org/10.1016/j.neuroimage.2022.119410",
+    "iQSM+ orientation-adaptive end-to-end deep-learning reconstruction (weights auto-downloaded) — https://doi.org/10.1016/j.media.2024.103160",
 ];
 const UNWRAP_HELP: &[&str] = &[
     "ROMEO region-growing unwrapping — https://doi.org/10.1002/mrm.28563",
@@ -928,6 +939,8 @@ const BF_HELP: &[&str] = &[
     "Regularized SHARP (RESHARP) with Tikhonov — https://doi.org/10.1002/mrm.25032",
     "HARPERELLA integrated unwrap+BFR — https://doi.org/10.1002/nbm.3056",
     "Improved HARPERELLA (iHARPERELLA) — Li et al., Proc. ISMRM 2015, p.3313",
+    "BFRnet deep-learning background removal (weights auto-downloaded) — https://github.com/sunhongfu/BFRnet",
+    "iQFM deep-learning joint unwrapping + background removal from phase (weights auto-downloaded) — https://doi.org/10.1016/j.neuroimage.2022.119410",
 ];
 const QSM_REF_HELP: &[&str] = &[
     "Subtract mean susceptibility within mask (recommended)",
@@ -1060,6 +1073,11 @@ pub struct PipelineFormState {
     pub iharperella_radius: String,
     pub iharperella_max_iter: String,
     pub iharperella_tol: String,
+
+    // mSMV boundary-shadow refinement (post-step on the primary BFR)
+    pub msmv_refine: bool,
+    pub msmv_radius: String,
+    pub msmv_maxk: String,
 
     // QSMART
     pub qsmart_ilsqr_tol: String,
@@ -1307,6 +1325,9 @@ impl Default for PipelineFormState {
             iharperella_radius: format!("{}", qsm_core::bgremove::HarperellaParams::default().radius),
             iharperella_max_iter: format!("{}", qsm_core::bgremove::HarperellaParams::default().max_iter),
             iharperella_tol: format!("{}", qsm_core::bgremove::HarperellaParams::default().tol),
+            msmv_refine: false,
+            msmv_radius: format!("{}", qsm_core::bgremove::MsmvParams::default().radius),
+            msmv_maxk: format!("{}", qsm_core::bgremove::MsmvParams::default().maxk),
             do_qsm: true,
             romeo_phase_gradient_coherence: qsm_core::unwrap::RomeoParams::default().phase_gradient_coherence,
             romeo_mag_coherence: qsm_core::unwrap::RomeoParams::default().mag_coherence,
@@ -1432,8 +1453,8 @@ impl Default for PipelineFormState {
     }
 }
 
-pub const QSM_ALGO_OPTIONS: &[&str] = &["rts", "tv", "tkd", "tsvd", "tgv", "tikhonov", "nltv", "medi", "tfi", "ilsqr", "qsmart", "ndi", "fansi", "fansi-tgv", "l1qsm", "whqsm", "hdqsm", "amp-pe"];
-pub const SEP_ALGO_OPTIONS: &[&str] = &["r2star-qsm", "decompose", "chi-sep-ilsqr", "chi-sep-medi", "wavesep", "hc-chisep"];
+pub const QSM_ALGO_OPTIONS: &[&str] = &["rts", "tv", "tkd", "tsvd", "tgv", "tikhonov", "nltv", "medi", "tfi", "ilsqr", "qsmart", "ndi", "fansi", "fansi-tgv", "l1qsm", "whqsm", "hdqsm", "amp-pe", "xqsm", "qsmnet", "qsmnet-plus", "autoqsm", "qsmgan", "ir2qsm", "lpcnn", "modl-qsm", "nextqsm", "iqsm", "iqsm-plus"];
+pub const SEP_ALGO_OPTIONS: &[&str] = &["r2star-qsm", "decompose", "chi-sep-ilsqr", "chi-sep-medi", "wavesep", "hc-chisep", "susep-net", "chi-sepnet"];
 const SEP_ALGO_HELP: &[&str] = &[
     "R2*-QSM closed-form (Dimov 2022) — QSM + R2*, GRE-only",
     "DECOMPOSE-QSM signal-domain fit (Chen 2021) — QSM + multi-echo magnitude, GRE-only",
@@ -1441,6 +1462,8 @@ const SEP_ALGO_HELP: &[&str] = &[
     "χ-separation MEDI — local field + R2' + magnitude",
     "WaveSep wavelet-L1 (Fang 2023) — QSM + R2'",
     "Hollow-cylinder χ-separation (Stewart 2026) — QSM + R2' + multi-echo magnitude",
+    "SUSEP-Net deep-learning separation — QSM + R2' + local field (weights auto-downloaded)",
+    "χ-sepnet deep-learning separation — QSM + R2' + local field (weights auto-downloaded)",
 ];
 // QSMART's inner dipole inversion (excludes the two end-to-end algorithms tgv/qsmart).
 pub const QSMART_INV_OPTIONS: &[&str] = &["ilsqr", "rts", "tv", "tkd", "tsvd", "tikhonov", "nltv", "medi"];
@@ -1455,7 +1478,7 @@ const QSMART_INV_HELP: &[&str] = &[
     "Morphology Enabled Dipole Inversion (MEDI)",
 ];
 pub const UNWRAP_OPTIONS: &[&str] = &["romeo", "laplacian"];
-pub const BF_OPTIONS: &[&str] = &["vsharp", "pdf", "lbv", "ismv", "sharp", "resharp", "harperella", "iharperella"];
+pub const BF_OPTIONS: &[&str] = &["vsharp", "pdf", "lbv", "ismv", "sharp", "resharp", "harperella", "iharperella", "bfrnet", "iqfm"];
 pub const B0_ESTIMATION_OPTIONS: &[&str] = &["weighted-avg", "linear-fit"];
 pub const B0_WEIGHT_TYPE_OPTIONS: &[&str] = &["phase-snr", "phase-var", "average", "tes", "mag"];
 const B0_ESTIMATION_HELP: &[&str] = &[
@@ -1553,6 +1576,13 @@ impl PipelineFormState {
         let is_tgv = self.qsm_algorithm == 4;
         let is_qsmart = self.qsm_algorithm == 10;
         let is_medi_smv = self.qsm_algorithm == 7 && self.medi_smv;
+        // AutoQSM / NeXtQSM are single-step (own background removal from the total field), so
+        // the BG-removal section is hidden — but field mapping/unwrapping still runs.
+        let is_autoqsm = self.qsm_algorithm == 21;
+        let is_nextqsm = self.qsm_algorithm == 26;
+        let is_single_step = is_autoqsm || is_nextqsm;
+        // iQSM / iQSM+ reconstruct end-to-end from raw phase: no field mapping or BG removal.
+        let is_iqsm = self.qsm_algorithm == 27 || self.qsm_algorithm == 28;
 
         // QSM toggle
         rows.push(PipelineRow::Toggle {
@@ -1578,7 +1608,7 @@ impl PipelineFormState {
 
         if self.do_qsm {
         // Field Mapping (hidden if TGV or QSMART)
-        if !is_tgv && !is_qsmart {
+        if !is_tgv && !is_qsmart && !is_iqsm {
             let is_laplacian = self.unwrapping_algorithm == 1;
 
             // Phase offset removal (disabled for Laplacian)
@@ -1674,8 +1704,8 @@ impl PipelineFormState {
 
         rows.push(PipelineRow::Separator);
 
-        // BG Removal (hidden for TGV, QSMART, and MEDI+SMV)
-        if !is_tgv && !is_qsmart && !is_medi_smv {
+        // BG Removal (hidden for TGV, QSMART, MEDI+SMV, single-step DL, and end-to-end iQSM)
+        if !is_tgv && !is_qsmart && !is_medi_smv && !is_single_step && !is_iqsm {
             rows.push(PipelineRow::AlgoSelect {
                 label: "BG Removal", field: "bf_algorithm",
                 options: BF_OPTIONS, help: BF_HELP,
@@ -1718,6 +1748,15 @@ impl PipelineFormState {
                     rows.push(PipelineRow::Param { label: "  Tolerance", field: "iharperella_tol", help: "Convergence tolerance" });
                 }
                 _ => {}
+            }
+            // mSMV boundary-shadow refinement, layered on top of the primary BFR (Roberts 2024).
+            rows.push(PipelineRow::Toggle {
+                label: "mSMV refinement", field: "msmv_refine",
+                help: "Remove residual boundary-field shadows with mSMV after the primary BFR (Roberts 2024)",
+            });
+            if self.msmv_refine {
+                rows.push(PipelineRow::Param { label: "  mSMV Radius", field: "msmv_radius", help: "SMV prefilter kernel radius in mm" });
+                rows.push(PipelineRow::Param { label: "  mSMV Max Iter", field: "msmv_maxk", help: "Maximum boundary-correction iterations" });
             }
             rows.push(PipelineRow::Separator);
         }
@@ -1952,6 +1991,7 @@ impl PipelineFormState {
         "resharp_radius", "resharp_tik_reg", "resharp_tol", "resharp_max_iter",
         "harperella_radius", "harperella_max_iter", "harperella_tol",
         "iharperella_radius", "iharperella_max_iter", "iharperella_tol",
+        "msmv_radius", "msmv_maxk",
         "qsmart_ilsqr_tol", "qsmart_ilsqr_max_iter", "qsmart_vasc_sphere_radius", "qsmart_sdf_spatial_radius",
         "qsmart_sdf_sigma1_stage1", "qsmart_sdf_sigma2_stage1", "qsmart_sdf_sigma1_stage2", "qsmart_sdf_sigma2_stage2",
         "qsmart_sdf_lower_lim", "qsmart_sdf_curv_constant",
@@ -2035,6 +2075,8 @@ impl PipelineFormState {
             "iharperella_radius" => &self.iharperella_radius,
             "iharperella_max_iter" => &self.iharperella_max_iter,
             "iharperella_tol" => &self.iharperella_tol,
+            "msmv_radius" => &self.msmv_radius,
+            "msmv_maxk" => &self.msmv_maxk,
             "qsmart_ilsqr_tol" => &self.qsmart_ilsqr_tol,
             "qsmart_ilsqr_max_iter" => &self.qsmart_ilsqr_max_iter,
             "qsmart_vasc_sphere_radius" => &self.qsmart_vasc_sphere_radius,
@@ -2202,6 +2244,8 @@ impl PipelineFormState {
             "iharperella_radius" => Some(&mut self.iharperella_radius),
             "iharperella_max_iter" => Some(&mut self.iharperella_max_iter),
             "iharperella_tol" => Some(&mut self.iharperella_tol),
+            "msmv_radius" => Some(&mut self.msmv_radius),
+            "msmv_maxk" => Some(&mut self.msmv_maxk),
             "qsmart_ilsqr_tol" => Some(&mut self.qsmart_ilsqr_tol),
             "qsmart_ilsqr_max_iter" => Some(&mut self.qsmart_ilsqr_max_iter),
             "qsmart_vasc_sphere_radius" => Some(&mut self.qsmart_vasc_sphere_radius),
@@ -2344,6 +2388,7 @@ impl PipelineFormState {
             "romeo_correct_global" => self.romeo_correct_global,
             "medi_smv" => self.medi_smv,
             "do_chi_separation" => self.do_chi_separation,
+            "msmv_refine" => self.msmv_refine,
             _ => false,
         }
     }
@@ -2359,6 +2404,7 @@ impl PipelineFormState {
             "romeo_individual" => self.romeo_individual = !self.romeo_individual,
             "romeo_correct_global" => self.romeo_correct_global = !self.romeo_correct_global,
             "medi_smv" => self.medi_smv = !self.medi_smv,
+            "msmv_refine" => self.msmv_refine = !self.msmv_refine,
             _ => {}
         }
     }

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -125,6 +125,18 @@ pub fn build_run_args(app: &App) -> crate::Result<RunArgs> {
         QsmAlgorithmArg::L1qsm,
         QsmAlgorithmArg::Whqsm,
         QsmAlgorithmArg::Hdqsm,
+        QsmAlgorithmArg::AmpPe,
+        QsmAlgorithmArg::Xqsm,
+        QsmAlgorithmArg::Qsmnet,
+        QsmAlgorithmArg::QsmnetPlus,
+        QsmAlgorithmArg::Autoqsm,
+        QsmAlgorithmArg::Qsmgan,
+        QsmAlgorithmArg::Ir2qsm,
+        QsmAlgorithmArg::Lpcnn,
+        QsmAlgorithmArg::ModlQsm,
+        QsmAlgorithmArg::Nextqsm,
+        QsmAlgorithmArg::Iqsm,
+        QsmAlgorithmArg::IqsmPlus,
     ];
     let unwrap_options = [UnwrapAlgorithmArg::Romeo, UnwrapAlgorithmArg::Laplacian];
     let bf_options = [
@@ -136,6 +148,8 @@ pub fn build_run_args(app: &App) -> crate::Result<RunArgs> {
         BfAlgorithmArg::Resharp,
         BfAlgorithmArg::Harperella,
         BfAlgorithmArg::Iharperella,
+        BfAlgorithmArg::Bfrnet,
+        BfAlgorithmArg::Iqfm,
     ];
     let sep_options = [
         SeparationAlgorithmArg::R2starQsm,
@@ -144,6 +158,8 @@ pub fn build_run_args(app: &App) -> crate::Result<RunArgs> {
         SeparationAlgorithmArg::ChiSepMedi,
         SeparationAlgorithmArg::Wavesep,
         SeparationAlgorithmArg::HcChisep,
+        SeparationAlgorithmArg::SusepNet,
+        SeparationAlgorithmArg::ChiSepNet,
     ];
     Ok(RunArgs {
         bids_dir: expand_tilde(&form.bids_dir),
@@ -397,6 +413,11 @@ pub fn build_run_args(app: &App) -> crate::Result<RunArgs> {
             iharperella_max_iter: parse_optional_usize(&ps.iharperella_max_iter),
             iharperella_tol: parse_optional_f64(&ps.iharperella_tol),
         },
+        msmv_params: crate::cli::MsmvParamArgs {
+            msmv_refine: ps.msmv_refine,
+            msmv_radius: parse_optional_f64(&ps.msmv_radius),
+            msmv_maxk: parse_optional_usize(&ps.msmv_maxk),
+        },
         romeo_params: crate::cli::RomeoParamArgs {
             no_romeo_phase_gradient_coherence: !ps.romeo_phase_gradient_coherence,
             no_romeo_mag_coherence: !ps.romeo_mag_coherence,
@@ -551,12 +572,15 @@ pub fn config_from_app(app: &App) -> PipelineConfig {
         QsmAlgorithm::Ndi, QsmAlgorithm::Fansi, QsmAlgorithm::FansiTgv,
         QsmAlgorithm::L1qsm, QsmAlgorithm::Whqsm, QsmAlgorithm::Hdqsm,
         QsmAlgorithm::AmpPe,
+        QsmAlgorithm::Xqsm, QsmAlgorithm::Qsmnet, QsmAlgorithm::QsmnetPlus, QsmAlgorithm::Autoqsm,
+        QsmAlgorithm::Qsmgan, QsmAlgorithm::Ir2qsm, QsmAlgorithm::Lpcnn, QsmAlgorithm::ModlQsm,
+        QsmAlgorithm::Nextqsm, QsmAlgorithm::Iqsm, QsmAlgorithm::IqsmPlus,
     ];
     let unwrap_algorithms = [UnwrappingAlgorithm::Romeo, UnwrappingAlgorithm::Laplacian];
     let bf_algorithms = [
         BfAlgorithm::Vsharp, BfAlgorithm::Pdf, BfAlgorithm::Lbv,
         BfAlgorithm::Ismv, BfAlgorithm::Sharp, BfAlgorithm::Resharp,
-        BfAlgorithm::Harperella, BfAlgorithm::Iharperella,
+        BfAlgorithm::Harperella, BfAlgorithm::Iharperella, BfAlgorithm::Bfrnet, BfAlgorithm::Iqfm,
     ];
 
     let qsm_algorithm = qsm_algorithms[ps.qsm_algorithm];
@@ -576,6 +600,7 @@ pub fn config_from_app(app: &App) -> PipelineConfig {
         SeparationAlgorithm::R2starQsm, SeparationAlgorithm::Decompose,
         SeparationAlgorithm::ChiSepIlsqr, SeparationAlgorithm::ChiSepMedi,
         SeparationAlgorithm::WaveSep, SeparationAlgorithm::HcChisep,
+        SeparationAlgorithm::SusepNet, SeparationAlgorithm::ChiSepNet,
     ];
     config.separation.algorithm = sep_algorithms[ps.separation_algorithm.min(sep_algorithms.len() - 1)];
     config.separation.custom_qsm_tool = non_empty(&ps.custom_qsm_tool);
@@ -586,6 +611,7 @@ pub fn config_from_app(app: &App) -> PipelineConfig {
     if !is_end_to_end {
         config.field_mapping.unwrapping_algorithm = unwrap_algorithms[ps.unwrapping_algorithm];
         config.bg_removal.algorithm = bf_algorithms[ps.bf_algorithm];
+        config.bg_removal.msmv_refine = ps.msmv_refine;
     }
     config.field_mapping.phase_offset_removal = ps.phase_offset_removal;
     config.field_mapping.bipolar_correction = ps.bipolar_correction;
@@ -811,6 +837,8 @@ pub fn config_from_app(app: &App) -> PipelineConfig {
     set_f64!(config.bg_removal.iharperella.radius, ps.iharperella_radius);
     set_usize!(config.bg_removal.iharperella.max_iter, ps.iharperella_max_iter);
     set_f64!(config.bg_removal.iharperella.tol, ps.iharperella_tol);
+    set_f64!(config.bg_removal.msmv.radius, ps.msmv_radius);
+    set_usize!(config.bg_removal.msmv.maxk, ps.msmv_maxk);
 
     // Phase offset sigma
     if let Ok(vals) = ps.phase_offset_sigma.split_whitespace()


### PR DESCRIPTION
Bumps qsm-core to **v0.27.1** (features: parallel, onnx, download) and wires every new algorithm across config/bridge/methods/CLI/TUI/runner and standalone commands.

## Background removal
- **mSMV** boundary-shadow refinement (Roberts 2024) as a `--msmv-refine` post-step on the primary BFR + standalone `bgremove msmv`.
- **BFRnet** and **iQFM** deep-learning options (weights auto-downloaded at run time).

## Dipole inversion (deep learning)
- xQSM, QSMnet, QSMnet+, AutoQSM, QSMGAN, IR2QSM, LPCNN, MoDL-QSM, NeXtQSM (AutoQSM/NeXtQSM single-step → skip BFR), and end-to-end **iQSM / iQSM+** from wrapped phase (new `stage_iqsm`, mirrors `stage_tgv`). Standalone `invert` covers the field-input DL inversions.

## Source separation (deep learning)
- **SUSEP-Net** and **χ-sepnet**, wired into `run` / TUI and standalone `separate`.

## Notes
- iQSM/iQSM+/iQFM take phase+TE+B0, so they're `run`-pipeline only (no standalone `invert`).
- onnx pulls tract → `kstring` pinned to 2.0.2 (rustc 1.95 vs 1.96).
- Fixes a latent TUI bug where `build_run_args`' qsm_options was missing AmpPe.

Depends on QSM.rs v0.27.1 (astewartau/QSM.rs#68). 541 + 94 tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)