### PR TITLE
feat: download progress bar for deep-learning model weights

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "qsm-core"
 version = "0.0.0"
-source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.27.1#d603de84352f3a1c9e15107bef0daeefb1f3a61c"
+source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.27.2#a822967017c298568ead98608f725f191a1abcb9"
 dependencies = [
  "bytemuck",
  "delaunator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "qsmxt"
 path = "src/main.rs"
 
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.27.1", features = ["parallel", "onnx", "download"] }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.27.2", features = ["parallel", "onnx", "download"] }
 qsmxt-config = { path = "crates/qsmxt-config" }
 clap = { version = "4", features = ["derive"] }
 const_format = "0.2"

--- a/crates/qsmxt-config/Cargo.toml
+++ b/crates/qsmxt-config/Cargo.toml
@@ -6,7 +6,7 @@ description = "Pipeline configuration, command generation, and methods text for 
 license = "GPL-3.0-only"
 
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.27.1" }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.27.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"

--- a/src/commands/bgremove.rs
+++ b/src/commands/bgremove.rs
@@ -169,7 +169,8 @@ pub fn execute(cmd: BgremoveCommand) -> crate::Result<()> {
             let grid = qsm_core::Grid::new(nx, ny, nz, vsx, vsy, vsz);
             info!("Background removal (BFRnet, {}x{}x{})", grid.nx(), grid.ny(), grid.nz());
 
-            // Fetch the ONNX weights (cached under $QSM_MODEL_DIR / the download cache).
+            // Fetch the ONNX weights with a download bar (cached under $QSM_MODEL_DIR / the cache).
+            crate::pipeline::runner::prefetch_weights("bfrnet", "bfrnet")?;
             let spec = qsm_core::models::find_model("bfrnet")
                 .ok_or_else(|| crate::error::QsmxtError::Config("bfrnet not in model registry".into()))?;
             let weights = qsm_core::models::primary_weight_bytes(spec)

--- a/src/commands/invert.rs
+++ b/src/commands/invert.rs
@@ -12,6 +12,10 @@ fn run_dl_inversion(
     let field_nifti = load_nifti(&c.input)?;
     let (mask, _) = load_mask(&c.mask)?;
     let (nx, ny, nz) = field_nifti.dims;
+    // Fetch the model's ONNX weights with a download bar before inference (cached afterwards).
+    if let Some(id) = algorithm.dl_model_id() {
+        crate::pipeline::runner::prefetch_weights(id, name)?;
+    }
     info!("Dipole inversion ({}, {}x{}x{})", name, nx, ny, nz);
     let metadata = qsm_core::pipeline::ScanMetadata {
         dims: field_nifti.dims,

--- a/src/commands/separate.rs
+++ b/src/commands/separate.rs
@@ -256,6 +256,7 @@ pub fn execute(cmd: SeparateCommand) -> crate::Result<()> {
             let c = &args.common;
             let (qsm, mask, metadata, _) = load_common(c, &[])?;
             info!("Chi-separation (susep-net, {}x{}x{})", qsm.dims.0, qsm.dims.1, qsm.dims.2);
+            crate::pipeline::runner::prefetch_weights("susep-net", "susep-net")?;
             let local_field = load_nifti(&args.local_field)?;
             let r2prime = load_nifti(&args.r2prime)?;
             // SUSEP-Net has no user-tunable parameters; weights download on first use.
@@ -276,6 +277,7 @@ pub fn execute(cmd: SeparateCommand) -> crate::Result<()> {
             let c = &args.common;
             let (qsm, mask, metadata, _) = load_common(c, &[])?;
             info!("Chi-separation (chi-sepnet, {}x{}x{})", qsm.dims.0, qsm.dims.1, qsm.dims.2);
+            crate::pipeline::runner::prefetch_weights("chi-sepnet", "chi-sepnet")?;
             let local_field = load_nifti(&args.local_field)?;
             let r2prime = load_nifti(&args.r2prime)?;
             // χ-sepnet has no user-tunable parameters; weights download on first use.

--- a/src/pipeline/runner.rs
+++ b/src/pipeline/runner.rs
@@ -138,6 +138,50 @@ fn iter_progress_bar(run_key: &str, step_name: &str) -> (Box<dyn FnMut(usize, us
     (cb, None)
 }
 
+/// Create a byte-oriented progress bar for weight downloads, in the same visual style as
+/// [`create_progress_bar`] (spinner + `━╸─` bar) but showing size + transfer rate.
+fn create_download_bar(label: &str, total: u64) -> ProgressBar {
+    let pb = MULTI_PROGRESS.add(ProgressBar::new(total));
+    pb.set_style(
+        ProgressStyle::with_template(&format!(
+            "  {{spinner:.green}} {} [{{bar:30.cyan/dim}}] {{bytes}}/{{total_bytes}} ({{percent}}%) | {{elapsed_precise}} elapsed | {{bytes_per_sec}}",
+            label
+        ))
+        .unwrap()
+        .progress_chars("━╸─"),
+    );
+    pb
+}
+
+/// Pre-fetch a deep-learning model's weights (if `model_id` names one) with a download
+/// progress bar per weight file. No-op for classical algorithms (unknown id) or weights
+/// already cached — after this, qsm-core's inference path finds the files in the cache.
+fn prefetch_weights(model_id: &str, run_key: &str) -> crate::Result<()> {
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    let bars: RefCell<HashMap<String, ProgressBar>> = RefCell::new(HashMap::new());
+    let res = {
+        let mut cb = |name: &str, done: u64, total: u64| {
+            let mut m = bars.borrow_mut();
+            let bar = m
+                .entry(name.to_string())
+                .or_insert_with(|| create_download_bar(&format!("{} ↓ {}", run_key, name), total.max(1)));
+            if total > 0 {
+                bar.set_length(total);
+            }
+            bar.set_position(done);
+            if total > 0 && done >= total {
+                bar.finish_and_clear();
+            }
+        };
+        qsm_core::models::prefetch_with_progress(model_id, &mut cb)
+    };
+    for (_, bar) in bars.into_inner() {
+        bar.finish_and_clear();
+    }
+    res.map_err(|e| QsmxtError::Config(format!("weight download ({}): {}", model_id, e)))
+}
+
 /// Log step completion with timing.
 fn log_step_done(step_name: &str, start: Instant) {
     let elapsed = start.elapsed();
@@ -939,6 +983,8 @@ fn stage_chi_separation(ctx: &mut StageContext, mask_path: &Path, progress: &dyn
         se_magnitude_multi: se_multi.as_deref(),
     };
 
+    // Fetch DL weights (SUSEP-Net / χ-sepnet) with a download bar; no-op for classical methods.
+    prefetch_weights(&alg_name, &ctx.run.key.to_string())?;
     let (mut prog, _) = iter_progress_bar(&ctx.run.key.to_string(), &alg_name);
     let result = qsm_core::pipeline::run_separation(inputs, &metadata, &sep_config, &mut *prog)
         .map_err(|e| QsmxtError::Config(format!("chi-separation: {}", e)))?;
@@ -1079,6 +1125,7 @@ fn stage_iqsm(ctx: &mut StageContext, mask_path: &Path, progress: &dyn Fn(&str))
     );
     let phase_refs: Vec<&[f64]> = phases.iter().map(|p| p.as_slice()).collect();
     let mag_refs: Vec<&[f64]> = magnitudes.iter().map(|m| m.as_slice()).collect();
+    prefetch_weights(alg, &ctx.run.key.to_string())?;
     log::info!("{} reconstruction (end-to-end from phase)", if plus { "iQSM+" } else { "iQSM" });
     // Referencing is done by stage_reference, so request None from the pipeline runner.
     let chi = if plus {
@@ -1291,6 +1338,7 @@ fn stage_standard_qsm(
         );
         let phase_refs: Vec<&[f64]> = phases.iter().map(|p| p.as_slice()).collect();
         let mag_refs: Vec<&[f64]> = magnitudes.iter().map(|m| m.as_slice()).collect();
+        prefetch_weights("iqfm", &ctx.run.key.to_string())?;
         log::info!("Background removal (iQFM, deep-learning joint unwrap+BFR)");
         let local_field = qsm_core::pipeline::run_iqfm(&phase_refs, &mag_refs, &mask, &scan_meta)
             .map_err(|e| QsmxtError::Config(format!("iQFM: {}", e)))?;
@@ -1317,6 +1365,8 @@ fn stage_standard_qsm(
             ctx.meta.field_strength, ctx.meta.b0_direction,
         );
 
+        // Fetch DL weights (BFRnet) with a download bar before removal; no-op otherwise.
+        prefetch_weights(&bf_name, &ctx.run.key.to_string())?;
         log::info!("Background removal ({})", bf_name);
         let (mut prog, _) = iter_progress_bar(&ctx.run.key.to_string(), &bf_name);
         let bg_result = qsm_core::pipeline::run_bg_removal(
@@ -1415,6 +1465,8 @@ fn stage_standard_qsm(
             None
         };
 
+        // Fetch DL weights (with a download bar) before inference; no-op for classical algs.
+        prefetch_weights(&alg_name, &ctx.run.key.to_string())?;
         log::info!("Dipole inversion ({})", alg_name);
         let (mut prog, _) = iter_progress_bar(&ctx.run.key.to_string(), &alg_name);
         let chi = qsm_core::pipeline::run_dipole_inversion(

--- a/src/pipeline/runner.rs
+++ b/src/pipeline/runner.rs
@@ -156,7 +156,10 @@ fn create_download_bar(label: &str, total: u64) -> ProgressBar {
 /// Pre-fetch a deep-learning model's weights (if `model_id` names one) with a download
 /// progress bar per weight file. No-op for classical algorithms (unknown id) or weights
 /// already cached — after this, qsm-core's inference path finds the files in the cache.
-fn prefetch_weights(model_id: &str, run_key: &str) -> crate::Result<()> {
+/// `label` prefixes the bar (the pipeline passes the run key; standalone commands pass the
+/// algorithm name). Shared by the pipeline runner and the standalone `invert`/`bgremove`/
+/// `separate` commands.
+pub fn prefetch_weights(model_id: &str, label: &str) -> crate::Result<()> {
     use std::cell::RefCell;
     use std::collections::HashMap;
     let bars: RefCell<HashMap<String, ProgressBar>> = RefCell::new(HashMap::new());
@@ -165,7 +168,7 @@ fn prefetch_weights(model_id: &str, run_key: &str) -> crate::Result<()> {
             let mut m = bars.borrow_mut();
             let bar = m
                 .entry(name.to_string())
-                .or_insert_with(|| create_download_bar(&format!("{} ↓ {}", run_key, name), total.max(1)));
+                .or_insert_with(|| create_download_bar(&format!("{} ↓ {}", label, name), total.max(1)));
             if total > 0 {
                 bar.set_length(total);
             }


### PR DESCRIPTION
Shows a progress bar while fetching deep-learning model weights (2 MB–400 MB) before inference, in the same style as the algorithm progress bars.

- `create_download_bar` (bytes + transfer rate) + `prefetch_weights`, driven by qsm-core's new `models::prefetch_with_progress`. No-op for classical algorithms and already-cached weights.
- Invoked before every DL compute step: dipole inversion, BFRnet / iQFM background removal, iQSM / iQSM+ reconstruction, SUSEP-Net / χ-sepnet separation.

**Where weights cache:** `$QSM_MODEL_CACHE` → `$XDG_CACHE_HOME/qsm-rs/models` → `~/.cache/qsm-rs/models` (or bring-your-own via `$QSM_MODEL_DIR`).

Bumps qsm-core to v0.27.2 (adds the download-progress callback + the earlier OSF retry). Verified end-to-end: an `xqsm` run fetched `xqsm.onnx` (20 MB, SHA-verified) via the bar. 541 + 94 tests pass; clippy clean.

Depends on astewartau/QSM.rs#69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)