### PR TITLE
feat: optional deep-learning support (fixes Windows/ARM64 release build)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,8 @@ jobs:
     needs: coverage-gate
     runs-on: ${{ matrix.os }}
     strategy:
+      # Don't let one target's failure cancel the others — publish every binary that builds.
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -94,9 +96,13 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             dcm2niix_asset: win
+          # Windows on ARM: the ONNX engine's kernel lib (tract-linalg) can't build its
+          # hand-written ARM64 SIMD assembly under MSVC, so this target is built WITHOUT the
+          # `dl` feature — classical algorithms only; deep-learning ones report a clear error.
           - target: aarch64-pc-windows-msvc
             os: windows-latest
             dcm2niix_asset: none
+            cargo_flags: --no-default-features
     steps:
       - uses: actions/checkout@v4
 
@@ -128,7 +134,7 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} ${{ matrix.cargo_flags }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,17 @@ repository = "https://github.com/QSMxT/QSMxT"
 name = "qsmxt"
 path = "src/main.rs"
 
+[features]
+# Deep-learning models (ONNX inference + weight download). On by default. Disable with
+# --no-default-features to build for targets where the ONNX engine can't compile (e.g.
+# aarch64-pc-windows-msvc, where tract-linalg's ARM64 assembly won't build under MSVC);
+# such a build keeps all classical algorithms and reports a clear error if a DL algorithm
+# is selected.
+default = ["dl"]
+dl = ["qsm-core/onnx", "qsm-core/download"]
+
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.27.2", features = ["parallel", "onnx", "download"] }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.27.2", features = ["parallel"] }
 qsmxt-config = { path = "crates/qsmxt-config" }
 clap = { version = "4", features = ["derive"] }
 const_format = "0.2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,15 +1,23 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
+/// Whether this build includes deep-learning (ONNX) support — shown in `--version` so a
+/// non-`dl` build (e.g. the Windows/ARM64 binary) advertises the missing models up front.
+#[cfg(feature = "dl")]
+const DL_STATUS: &str = "deep-learning models: enabled";
+#[cfg(not(feature = "dl"))]
+const DL_STATUS: &str = "deep-learning models: DISABLED in this build (classical algorithms only)";
+
 #[derive(Parser, Debug)]
 #[command(
     name = "qsmxt",
     version,
     long_version = const_format::formatcp!(
-        "{}\nqsm-core: {} ({})",
+        "{}\nqsm-core: {} ({})\n{}",
         env!("CARGO_PKG_VERSION"),
         env!("QSM_CORE_VERSION"),
         env!("QSM_CORE_GIT_HASH"),
+        DL_STATUS,
     ),
     about = "QSMxT: Quantitative Susceptibility Mapping tool (Rust)"
 )]

--- a/src/commands/bgremove.rs
+++ b/src/commands/bgremove.rs
@@ -14,6 +14,30 @@ fn tissue_phase_to_ppm(phase: &mut [f64], te: f64, b0: f64) {
     }
 }
 
+/// BFRnet local-field estimation (deep learning). Split out so the non-`dl` build compiles
+/// without the ONNX-gated `qsm_core::bgremove::bfrnet` symbol; `prefetch_weights` guards the
+/// call site, so the no-DL body is effectively unreachable.
+#[cfg(feature = "dl")]
+fn bfrnet_local_field(
+    field: &qsm_core::io::NiftiData, mask: &[u8], grid: &qsm_core::Grid,
+) -> crate::Result<Vec<f64>> {
+    let spec = qsm_core::models::find_model("bfrnet")
+        .ok_or_else(|| crate::error::QsmxtError::Config("bfrnet not in model registry".into()))?;
+    let weights = qsm_core::models::primary_weight_bytes(spec)
+        .map_err(|e| crate::error::QsmxtError::Config(format!("BFRnet weights: {}", e)))?;
+    qsm_core::bgremove::bfrnet(&field.data, mask, grid, &weights)
+        .map_err(|e| crate::error::QsmxtError::Config(format!("BFRnet: {}", e)))
+}
+
+#[cfg(not(feature = "dl"))]
+fn bfrnet_local_field(
+    _field: &qsm_core::io::NiftiData, _mask: &[u8], _grid: &qsm_core::Grid,
+) -> crate::Result<Vec<f64>> {
+    Err(crate::error::QsmxtError::Config(
+        "BFRnet requires a deep-learning build of qsmxt".into(),
+    ))
+}
+
 pub fn execute(cmd: BgremoveCommand) -> crate::Result<()> {
     let (common, local_field, eroded_mask) = match cmd {
         BgremoveCommand::Vsharp(args) => {
@@ -170,13 +194,9 @@ pub fn execute(cmd: BgremoveCommand) -> crate::Result<()> {
             info!("Background removal (BFRnet, {}x{}x{})", grid.nx(), grid.ny(), grid.nz());
 
             // Fetch the ONNX weights with a download bar (cached under $QSM_MODEL_DIR / the cache).
+            // On a build without the `dl` feature this errors here with a clear message.
             crate::pipeline::runner::prefetch_weights("bfrnet", "bfrnet")?;
-            let spec = qsm_core::models::find_model("bfrnet")
-                .ok_or_else(|| crate::error::QsmxtError::Config("bfrnet not in model registry".into()))?;
-            let weights = qsm_core::models::primary_weight_bytes(spec)
-                .map_err(|e| crate::error::QsmxtError::Config(format!("BFRnet weights: {}", e)))?;
-            let lf = qsm_core::bgremove::bfrnet(&field_nifti.data, &mask, &grid, &weights)
-                .map_err(|e| crate::error::QsmxtError::Config(format!("BFRnet: {}", e)))?;
+            let lf = bfrnet_local_field(&field_nifti, &mask, &grid)?;
             // BFRnet preserves the brain edge (no erosion): mask returned unchanged.
             (c, (lf, field_nifti), mask)
         }

--- a/src/pipeline/runner.rs
+++ b/src/pipeline/runner.rs
@@ -140,6 +140,7 @@ fn iter_progress_bar(run_key: &str, step_name: &str) -> (Box<dyn FnMut(usize, us
 
 /// Create a byte-oriented progress bar for weight downloads, in the same visual style as
 /// [`create_progress_bar`] (spinner + `━╸─` bar) but showing size + transfer rate.
+#[cfg(feature = "dl")]
 fn create_download_bar(label: &str, total: u64) -> ProgressBar {
     let pb = MULTI_PROGRESS.add(ProgressBar::new(total));
     pb.set_style(
@@ -159,6 +160,7 @@ fn create_download_bar(label: &str, total: u64) -> ProgressBar {
 /// `label` prefixes the bar (the pipeline passes the run key; standalone commands pass the
 /// algorithm name). Shared by the pipeline runner and the standalone `invert`/`bgremove`/
 /// `separate` commands.
+#[cfg(feature = "dl")]
 pub fn prefetch_weights(model_id: &str, label: &str) -> crate::Result<()> {
     use std::cell::RefCell;
     use std::collections::HashMap;
@@ -183,6 +185,22 @@ pub fn prefetch_weights(model_id: &str, label: &str) -> crate::Result<()> {
         bar.finish_and_clear();
     }
     res.map_err(|e| QsmxtError::Config(format!("weight download ({}): {}", model_id, e)))
+}
+
+/// Build without the `dl` feature (e.g. the Windows/ARM64 binary): there is no ONNX
+/// inference or weight download. A classical algorithm (not a registry model) is a no-op;
+/// selecting a deep-learning algorithm fails here with a clear, actionable message instead
+/// of a confusing lower-level error.
+#[cfg(not(feature = "dl"))]
+pub fn prefetch_weights(model_id: &str, _label: &str) -> crate::Result<()> {
+    if qsm_core::models::find_model(model_id).is_some() {
+        return Err(QsmxtError::Config(format!(
+            "'{model_id}' is a deep-learning algorithm, which this build of qsmxt does not \
+             include (compiled without the 'dl' feature — e.g. the Windows/ARM64 binary). \
+             Pick a classical algorithm, or install a qsmxt build with deep-learning support.",
+        )));
+    }
+    Ok(())
 }
 
 /// Log step completion with timing.
@@ -1518,13 +1536,25 @@ mod tests {
 
     #[test]
     fn test_prefetch_weights_noop_and_download_bar() {
-        // Classical algorithm ids aren't registry models → prefetch is a no-op, no network.
+        // Classical algorithm ids aren't registry models → prefetch is a no-op (in both the
+        // `dl` and non-`dl` builds), no network.
         assert!(super::prefetch_weights("rts", "test").is_ok());
         assert!(super::prefetch_weights("vsharp", "test").is_ok());
-        // The download bar renders without touching the network.
-        let pb = super::create_download_bar("test ↓ x.onnx", 1000);
-        pb.set_position(500);
-        pb.finish_and_clear();
+        // The download bar renders without touching the network (only exists in `dl` builds).
+        #[cfg(feature = "dl")]
+        {
+            let pb = super::create_download_bar("test ↓ x.onnx", 1000);
+            pb.set_position(500);
+            pb.finish_and_clear();
+        }
+    }
+
+    #[cfg(not(feature = "dl"))]
+    #[test]
+    fn test_prefetch_weights_errors_for_dl_without_dl_feature() {
+        // Selecting a DL model in a non-DL build must fail with a clear message.
+        let err = super::prefetch_weights("qsmnet", "test").unwrap_err();
+        assert!(format!("{}", err).contains("deep-learning"), "got: {}", err);
     }
 
     #[test]


### PR DESCRIPTION
The ONNX engine's kernel lib (`tract-linalg`) can't build its hand-written ARM64 SIMD assembly under MSVC, so `aarch64-pc-windows-msvc` failed to compile once `onnx` was enabled — which **silently blocked the entire release binary matrix** (v9.12.0/v9.13.0 shipped no binaries).

Fix: make deep-learning an **opt-out** cargo feature so that target builds classical-only.

- `default = ["dl"]`, `dl = ["qsm-core/onnx", "qsm-core/download"]`; qsm-core base features drop to `["parallel"]`.
- Non-`dl` `prefetch_weights` returns a clear, actionable error if a DL algorithm is selected (no-op for classical). The one direct onnx-gated call (standalone `bgremove bfrnet`) is behind a cfg helper.
- `--version` reports whether DL is enabled.
- Release matrix: `aarch64-pc-windows-msvc` re-added, built `--no-default-features`; `fail-fast: false` so one target can't cancel the rest.

Verified: build + tests + clippy clean **with and without** `--no-default-features` (dl: 545 tests, no-dl: 546).

After merge I'll re-cut v9.13.0 so all 7 targets publish (ARM64-Windows = classical-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)