### PR TITLE
feat: DL overlap-tiling (CLI + TUI) + collapsible pipeline sections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "qsm-core"
 version = "0.0.0"
-source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.27.2#a822967017c298568ead98608f725f191a1abcb9"
+source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.28.0#ff0c2887d52ecec0509365b6ded5b4c0ea07edac"
 dependencies = [
  "bytemuck",
  "delaunator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = ["dl"]
 dl = ["qsm-core/onnx", "qsm-core/download"]
 
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.27.2", features = ["parallel"] }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.28.0", features = ["parallel"] }
 qsmxt-config = { path = "crates/qsmxt-config" }
 clap = { version = "4", features = ["derive"] }
 const_format = "0.2"

--- a/crates/qsmxt-config/Cargo.toml
+++ b/crates/qsmxt-config/Cargo.toml
@@ -6,7 +6,7 @@ description = "Pipeline configuration, command generation, and methods text for 
 license = "GPL-3.0-only"
 
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.27.2" }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.28.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"

--- a/crates/qsmxt-config/src/bridge.rs
+++ b/crates/qsmxt-config/src/bridge.rs
@@ -290,6 +290,10 @@ pub fn to_pipeline_stages(cfg: &PipelineConfig) -> (
             // ppm and b0_dir keep qsm-core defaults
             ..Default::default()
         },
+        // Overlap-tiling for the DL inversions: presence of `tile_size` enables it (core size);
+        // `tile_halo` defaults to 8 (qsm-core's TileConfig default) when omitted. `None` =
+        // whole-volume. Stored as `(core, halo)` so this crate needn't pull qsm-core's onnx feature.
+        tile: cfg.inversion.tile_size.map(|core| (core, cfg.inversion.tile_halo.unwrap_or(8))),
     };
 
     let reference = match cfg.qsm.reference {

--- a/crates/qsmxt-config/src/command.rs
+++ b/crates/qsmxt-config/src/command.rs
@@ -279,11 +279,21 @@ pub fn generate_command(config: &PipelineConfig) -> String {
             emit_f64(&mut parts, "--amp-pe-cvg-thd", a.cvg_thd, da.cvg_thd);
             emit_f64(&mut parts, "--amp-pe-tikhonov-beta", a.tikhonov_beta, da.tikhonov_beta);
         }
-        // Deep-learning inversions have no user-tunable parameters (weights + fixed graph).
-        QsmAlgorithm::Xqsm | QsmAlgorithm::Qsmnet
-        | QsmAlgorithm::QsmnetPlus | QsmAlgorithm::Autoqsm
-        | QsmAlgorithm::Qsmgan | QsmAlgorithm::Ir2qsm | QsmAlgorithm::Lpcnn
-        | QsmAlgorithm::ModlQsm | QsmAlgorithm::Nextqsm
+        // Deep-learning inversions have no per-net params (weights + fixed graph), but the
+        // tileable nets (routed through run_dipole_inversion) accept overlap-tiling options.
+        // Presence of `--tile-size` enables tiling; absence = whole-volume.
+        QsmAlgorithm::Xqsm | QsmAlgorithm::Qsmnet | QsmAlgorithm::QsmnetPlus
+        | QsmAlgorithm::Ir2qsm | QsmAlgorithm::Lpcnn | QsmAlgorithm::ModlQsm
+        | QsmAlgorithm::Nextqsm => {
+            if let Some(sz) = config.inversion.tile_size {
+                parts.push(format!("--tile-size {}", sz));
+            }
+            if let Some(h) = config.inversion.tile_halo {
+                parts.push(format!("--tile-halo {}", h));
+            }
+        }
+        // Natively patch-based (autoqsm/qsmgan) and phase-input (iqsm/iqsm+) nets: no tiling opts.
+        QsmAlgorithm::Autoqsm | QsmAlgorithm::Qsmgan
         | QsmAlgorithm::Iqsm | QsmAlgorithm::IqsmPlus => {}
     }
 
@@ -415,6 +425,29 @@ mod tests {
         c.pipeline.do_chi_separation = true;
         c.separation.algorithm = SeparationAlgorithm::ChiSepNet;
         assert!(generate_command(&c).contains("--chisep chi-sepnet"));
+    }
+
+    #[test]
+    fn test_dl_tiling_command() {
+        use crate::enums::QsmAlgorithm;
+        // Off by default: no tiling flags for a DL algorithm.
+        let mut c = PipelineConfig::default();
+        c.inversion.algorithm = QsmAlgorithm::Xqsm;
+        let cmd = generate_command(&c);
+        assert!(!cmd.contains("--tile-size"), "got: {}", cmd);
+        assert!(!cmd.contains("--tile-halo"), "got: {}", cmd);
+        // Setting tile_size enables tiling; halo emitted only when set.
+        c.inversion.tile_size = Some(64);
+        let cmd = generate_command(&c);
+        assert!(cmd.contains("--tile-size 64"), "got: {}", cmd);
+        assert!(!cmd.contains("--tile-halo"), "got: {}", cmd);
+        c.inversion.tile_halo = Some(4);
+        let cmd = generate_command(&c);
+        assert!(cmd.contains("--tile-size 64") && cmd.contains("--tile-halo 4"), "got: {}", cmd);
+        // Native-patch nets ignore tiling options (no flags emitted).
+        c.inversion.algorithm = QsmAlgorithm::Autoqsm;
+        let cmd = generate_command(&c);
+        assert!(!cmd.contains("--tile-size"), "autoqsm should not emit tiling: {}", cmd);
     }
 
     #[test]

--- a/crates/qsmxt-config/src/config.rs
+++ b/crates/qsmxt-config/src/config.rs
@@ -498,6 +498,15 @@ pub struct InversionConfig {
     pub whqsm: WhqsmConfig,
     pub hdqsm: HdqsmConfig,
     pub amp_pe: AmpPeConfig,
+    /// Overlap-tiling for deep-learning inversions (bounded memory). `tile_size` = the output core
+    /// per patch (voxels); its presence enables tiling. `tile_halo` = context margin per side
+    /// (voxels; a default is used when omitted). `None` = whole-volume (the default). Applies to
+    /// the DL nets that route through `run_dipole_inversion`; ignored by classical algorithms and
+    /// the natively-patch-based nets (autoqsm/qsmgan).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tile_size: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tile_halo: Option<usize>,
 }
 impl Default for InversionConfig {
     fn default() -> Self {
@@ -511,6 +520,7 @@ impl Default for InversionConfig {
             ndi: NdiConfig::default(), fansi: FansiConfig::default(),
             l1qsm: L1qsmConfig::default(), whqsm: WhqsmConfig::default(),
             hdqsm: HdqsmConfig::default(), amp_pe: AmpPeConfig::default(),
+            tile_size: None, tile_halo: None,
         }
     }
 }

--- a/crates/qsmxt-config/src/methods.rs
+++ b/crates/qsmxt-config/src/methods.rs
@@ -360,6 +360,21 @@ pub fn generate_methods_for(config: &PipelineConfig, tool: &str) -> String {
                 let (name, cite) = inversion_name_cite(config.inversion.algorithm);
                 sentences.push(format!("Dipole inversion was performed using {} ({}).", name, cite_inline(cite)));
                 add_citation(&mut citations, cite);
+                // Deep-learning tiling (memory-bounded, approximate) is noted when enabled — only
+                // for the tileable DL nets (a stray --tile-size on a classical algorithm is ignored).
+                let tileable = matches!(
+                    config.inversion.algorithm,
+                    QsmAlgorithm::Xqsm | QsmAlgorithm::Qsmnet | QsmAlgorithm::QsmnetPlus
+                        | QsmAlgorithm::Ir2qsm | QsmAlgorithm::Lpcnn | QsmAlgorithm::ModlQsm
+                        | QsmAlgorithm::Nextqsm
+                );
+                if let (true, Some(core)) = (tileable, config.inversion.tile_size) {
+                    let halo = config.inversion.tile_halo.unwrap_or(8);
+                    sentences.push(format!(
+                        "Inference was run overlap-tiled (tile size {core} voxels, halo {halo} voxels) \
+                         to bound memory; note that tiling approximates the whole-volume network.",
+                    ));
+                }
             }
         }
 
@@ -741,6 +756,20 @@ mod tests {
         assert!(out.contains("Total Generalized Variation (TGV)"));
         assert!(!out.contains("Phase unwrapping was performed"));
         assert!(!out.contains("Background field removal"));
+    }
+
+    #[test]
+    fn test_dl_tiling_methods() {
+        let mut config = PipelineConfig::default();
+        config.inversion.algorithm = QsmAlgorithm::Xqsm;
+        // No tiling sentence when tiling is off.
+        assert!(!generate_methods(&config).contains("overlap-tiled"));
+        // Sentence appears (with the sizes) when tiling is enabled.
+        config.inversion.tile_size = Some(64);
+        config.inversion.tile_halo = Some(4);
+        let out = generate_methods(&config);
+        assert!(out.contains("overlap-tiled"), "got: {}", out);
+        assert!(out.contains("tile size 64") && out.contains("halo 4"), "got: {}", out);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -186,6 +186,19 @@ pub struct TgvParamArgs {
     pub tgv_tol: Option<f64>,
 }
 
+/// Overlap-tiling for deep-learning inversions (bounded memory). Passing `--tile-size` enables
+/// tiling (the net runs patch-by-patch); omit it to run whole-volume. `--tile-halo` sets the
+/// context margin (defaults to 8 voxels). Tiling is an approximation of the whole-volume network.
+#[derive(Args, Debug, Default, Clone)]
+pub struct TilingParamArgs {
+    /// DL tiling: output core size per patch, in voxels (enables tiling)
+    #[arg(long)]
+    pub tile_size: Option<usize>,
+    /// DL tiling: context margin per side, in voxels (default 8)
+    #[arg(long)]
+    pub tile_halo: Option<usize>,
+}
+
 #[derive(Args, Debug, Default, Clone)]
 pub struct TikhonovParamArgs {
     /// Tikhonov lambda
@@ -909,6 +922,8 @@ pub struct RunArgs {
     pub romeo_params: RomeoParamArgs,
     #[command(flatten)]
     pub swi_params: SwiParamArgs,
+    #[command(flatten)]
+    pub tiling_params: TilingParamArgs,
 
 
     /// Number of parallel threads
@@ -1467,6 +1482,9 @@ pub struct InvertCommonArgs {
     /// B0 direction (3 values)
     #[arg(long, num_args = 3, default_values_t = [0.0, 0.0, 1.0])]
     pub b0_direction: Vec<f64>,
+    /// Deep-learning overlap-tiling (opt-in; ignored by classical algorithms).
+    #[command(flatten)]
+    pub tiling_params: TilingParamArgs,
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/commands/invert.rs
+++ b/src/commands/invert.rs
@@ -24,7 +24,9 @@ fn run_dl_inversion(
         field_strength,
         b0_direction: (c.b0_direction[0], c.b0_direction[1], c.b0_direction[2]),
     };
-    let config = qsm_core::pipeline::InversionConfig { algorithm, ..Default::default() };
+    // Opt-in overlap-tiling: presence of --tile-size enables it; halo defaults to 8.
+    let tile = c.tiling_params.tile_size.map(|core| (core, c.tiling_params.tile_halo.unwrap_or(8)));
+    let config = qsm_core::pipeline::InversionConfig { algorithm, tile, ..Default::default() };
     let chi = qsm_core::pipeline::run_dipole_inversion(
         &field_nifti.data, &mask, &metadata, &config, None, &mut |_, _| {},
     ).map_err(|e| crate::error::QsmxtError::Config(format!("{}: {}", name, e)))?;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -82,6 +82,7 @@ mod integration_tests {
             msmv_params: Default::default(),
             romeo_params: Default::default(),
             swi_params: Default::default(),
+            tiling_params: Default::default(),
             n_procs: Some(1),
             homogeneity_sigma_mm: None,
             homogeneity_nbox: None,
@@ -131,6 +132,7 @@ mod integration_tests {
         InvertCommonArgs {
             input, mask, output,
             b0_direction: vec![0.0, 0.0, 1.0],
+            tiling_params: Default::default(),
         }
     }
 

--- a/src/pipeline/config.rs
+++ b/src/pipeline/config.rs
@@ -206,6 +206,9 @@ pub fn apply_run_overrides(config: &mut PipelineConfig, args: &cli::RunArgs) {
         if let Some(v) = args.tgv_params.tgv_alpha0 { config.inversion.tgv.alpha0 = v; }
         if let Some(v) = args.tgv_params.tgv_step_size { config.inversion.tgv.step_size = v; }
         if let Some(v) = args.tgv_params.tgv_tol { config.inversion.tgv.tol = v; }
+        // Deep-learning overlap-tiling (opt-in): presence of --tile-size enables it.
+        if let Some(v) = args.tiling_params.tile_size { config.inversion.tile_size = Some(v); }
+        if let Some(v) = args.tiling_params.tile_halo { config.inversion.tile_halo = Some(v); }
         if let Some(v) = args.ndi_params.ndi_tau { config.inversion.ndi.tau = v; }
         if let Some(v) = args.ndi_params.ndi_alpha { config.inversion.ndi.alpha = v; }
         if let Some(v) = args.ndi_params.ndi_max_iter { config.inversion.ndi.max_iter = v; }

--- a/src/pipeline/memory.rs
+++ b/src/pipeline/memory.rs
@@ -136,6 +136,15 @@ fn estimate_standard_pipeline(n: usize, n_echoes: usize, config: &PipelineConfig
     // Dipole inversion
     // Input: local_field (8N) + eroded_mask (N) carry forward from bg stage
     let inv_carry = 9 * n;
+    // With overlap-tiling on, a DL net's activations are bounded by one patch, not the whole
+    // volume — use the padded patch voxel count for the tileable nets (never more than `n`).
+    let dl_voxels = match config.inversion.tile_size {
+        Some(core) => {
+            let halo = config.inversion.tile_halo.unwrap_or(8);
+            (core + 2 * halo).saturating_pow(3).min(n)
+        }
+        None => n,
+    };
     let inv_temp = match config.inversion.algorithm {
         // TKD: dipole kernel + inverse + complex field + output
         QsmAlgorithm::Tkd => 40 * n,
@@ -172,14 +181,17 @@ fn estimate_standard_pipeline(n: usize, n_echoes: usize, config: &PipelineConfig
         QsmAlgorithm::AmpPe => 260 * n,
         // Deep-learning inversions: ONNX U-Net activations dominate. QSMnet/QSMnet+ are the
         // heaviest (deeper 3D U-Net, /16 padding); xQSM/AutoQSM are lighter patch/octave nets.
-        QsmAlgorithm::Qsmnet | QsmAlgorithm::QsmnetPlus => 200 * n,
-        QsmAlgorithm::Xqsm | QsmAlgorithm::Autoqsm => 120 * n,
+        // `dl_voxels` == `n` unless tiling is enabled (then it's one patch); autoqsm/qsmgan patch
+        // natively (unaffected by the tiling flag) and iqsm/iqsm+ take a separate phase path.
+        QsmAlgorithm::Qsmnet | QsmAlgorithm::QsmnetPlus => 200 * dl_voxels,
+        QsmAlgorithm::Xqsm => 120 * dl_voxels,
+        QsmAlgorithm::Autoqsm => 120 * n,
         // Other DL nets: unrolled/patch/single-step U-Nets. NeXtQSM (two U-Nets + unroll)
         // and iQSM/iQSM+ (per-echo passes) are the heaviest; the rest are moderate.
-        QsmAlgorithm::Nextqsm => 220 * n,
+        QsmAlgorithm::Nextqsm => 220 * dl_voxels,
         QsmAlgorithm::Iqsm | QsmAlgorithm::IqsmPlus => 200 * n,
-        QsmAlgorithm::Qsmgan | QsmAlgorithm::Ir2qsm
-        | QsmAlgorithm::Lpcnn | QsmAlgorithm::ModlQsm => 140 * n,
+        QsmAlgorithm::Qsmgan => 140 * n,
+        QsmAlgorithm::Ir2qsm | QsmAlgorithm::Lpcnn | QsmAlgorithm::ModlQsm => 140 * dl_voxels,
     };
 
     // Peak is the maximum across the three sequential stages

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -867,6 +867,11 @@ pub enum PipelineRow {
     Separator,
     /// Informational hint line (styled, not focusable)
     Note { text: &'static str },
+    /// Collapsible stage header on the QSM pipeline page (General, Field mapping, Masking,
+    /// Background removal, Dipole inversion, Referencing). Focusable; Enter/Space or ←/→ toggles
+    /// it. `summary` shows the stage's current choice when collapsed; `id` is a stable key for the
+    /// collapse state and `label` the display name.
+    SectionHeader { id: &'static str, label: &'static str, summary: String, collapsed: bool },
     /// Section header "── Mask N ──" (not focusable)
     MaskSectionHeader { section: usize },
     /// "── OR ──" separator between sections (not focusable)
@@ -900,31 +905,40 @@ pub const MASK_PRESET_HELP: &[&str] = &[
 
 // ─── Algorithm help text (name + DOI) ───
 
+// One entry per QSM_ALGO_OPTIONS entry, in the same order. Consistent format:
+//   "NAME (expansion) — one-line description. https://doi.org/…"
+// Deep-learning nets are marked "(deep learning; weights auto-downloaded)". Keep this aligned
+// with QSM_ALGO_OPTIONS — the coverage test asserts equal lengths.
 const QSM_ALGO_HELP: &[&str] = &[
-    "Rapid Two-Step (RTS) — https://doi.org/10.1016/j.neuroimage.2017.11.018",
-    "Total Variation ADMM (TV) — https://doi.org/10.1002/mrm.25029",
-    "Truncated K-space Division (TKD) — https://doi.org/10.1002/mrm.22135",
-    "Total Generalized Variation (TGV, single-step) — https://doi.org/10.1016/j.neuroimage.2015.02.041",
-    "Tikhonov L2 regularization (closed-form) — https://doi.org/10.1002/jmri.24365",
-    "Nonlinear Total Variation (NLTV) — https://doi.org/10.1016/j.neuroimage.2017.11.018",
-    "Morphology Enabled Dipole Inversion (MEDI) — https://doi.org/10.1002/mrm.22816",
-    "Nonlinear Dipole Inversion (NDI) — https://doi.org/10.1002/nbm.4271",
-    "FANSI Nonlinear TV (nlTV) — https://doi.org/10.1002/mrm.27073",
-    "FANSI Nonlinear TGV (nlTGV) — https://doi.org/10.1002/mrm.27073",
-    "L1-QSM (L1 data fidelity) — https://doi.org/10.1002/mrm.29057",
-    "Weak-Harmonic QSM (WH-QSM) — https://doi.org/10.1002/mrm.27483",
-    "Hybrid Data Fidelity QSM (HD-QSM) — https://doi.org/10.1002/mrm.29296",
-    "xQSM deep-learning dipole inversion (weights auto-downloaded) — https://doi.org/10.1002/nbm.4461",
-    "QSMnet deep-learning dipole inversion (weights auto-downloaded) — https://doi.org/10.1016/j.neuroimage.2018.06.030",
-    "QSMnet+ deep-learning dipole inversion (weights auto-downloaded) — https://doi.org/10.1016/j.neuroimage.2020.116579",
-    "AutoQSM single-step deep-learning reconstruction, no BFR (weights auto-downloaded) — https://doi.org/10.1016/j.neuroimage.2019.116064",
-    "QSMGAN GAN-refined deep-learning dipole inversion (weights auto-downloaded) — https://doi.org/10.1016/j.neuroimage.2019.116389",
-    "IR2QSM unrolled deep-learning dipole inversion (weights auto-downloaded) — https://doi.org/10.1002/mp.17747",
-    "LPCNN learned-proximal deep-learning dipole inversion (weights auto-downloaded) — https://doi.org/10.1007/978-3-030-59713-9_13",
-    "MoDL-QSM model-based deep-learning dipole inversion, χ33/STI (weights auto-downloaded) — https://doi.org/10.1016/j.neuroimage.2021.118376",
-    "NeXtQSM single-step deep-learning reconstruction, no BFR (weights auto-downloaded) — https://doi.org/10.1016/j.neuroimage.2022.119729",
-    "iQSM end-to-end deep-learning reconstruction from phase (weights auto-downloaded) — https://doi.org/10.1016/j.neuroimage.2022.119410",
-    "iQSM+ orientation-adaptive end-to-end deep-learning reconstruction (weights auto-downloaded) — https://doi.org/10.1016/j.media.2024.103160",
+    "RTS (Rapid Two-Step) — fast two-step k-space inversion with streaking removal. https://doi.org/10.1016/j.neuroimage.2017.11.018",
+    "TV-ADMM (Total Variation) — ADMM inversion with a total-variation prior. https://doi.org/10.1002/mrm.25029",
+    "TKD (Thresholded K-space Division) — direct k-space division with thresholding. https://doi.org/10.1002/mrm.22135",
+    "TSVD (Truncated SVD) — zeroes the small singular values of the dipole kernel. https://doi.org/10.1002/mrm.22135",
+    "TGV (Total Generalized Variation) — single-step: unwrapping, background removal and inversion together. https://doi.org/10.1016/j.neuroimage.2015.02.041",
+    "Tikhonov — closed-form L2-regularized inversion. https://doi.org/10.1002/jmri.24365",
+    "NLTV (Nonlinear Total Variation) — nonlinear data fidelity with a TV prior. https://doi.org/10.1016/j.neuroimage.2017.11.018",
+    "MEDI (Morphology Enabled Dipole Inversion) — magnitude-guided edge weighting. https://doi.org/10.1002/mrm.22816",
+    "TFI (Total Field Inversion) — inverts the total field directly (its own background removal). https://doi.org/10.1002/mrm.26331",
+    "iLSQR — iterative LSQR with streaking-artifact correction. https://doi.org/10.1016/j.neuroimage.2014.12.043",
+    "QSMART — two-stage spatially-dependent filtering plus inversion. https://doi.org/10.1016/j.neuroimage.2020.117701",
+    "NDI (Nonlinear Dipole Inversion) — gradient-descent nonlinear fit. https://doi.org/10.1002/nbm.4271",
+    "FANSI (Nonlinear TV) — fast nonlinear susceptibility inversion with a TV prior. https://doi.org/10.1002/mrm.27073",
+    "FANSI (Nonlinear TGV) — FANSI with a total-generalized-variation prior. https://doi.org/10.1002/mrm.27073",
+    "L1-QSM (L1 Data Fidelity) — L1 fidelity for streaking suppression. https://doi.org/10.1002/mrm.29057",
+    "WH-QSM (Weak-Harmonic QSM) — jointly fits a residual harmonic background field. https://doi.org/10.1002/mrm.27483",
+    "HD-QSM (Hybrid Data Fidelity) — combined L1/L2 data fidelity. https://doi.org/10.1002/mrm.29296",
+    "AMP-PE (Approximate Message Passing with Parameter Estimation) — self-tuning Bayesian inversion. https://doi.org/10.1002/mrm.29725",
+    "xQSM (deep learning; weights auto-downloaded) — octave-convolution U-net dipole inversion. https://doi.org/10.1002/nbm.4461",
+    "QSMnet (deep learning; weights auto-downloaded) — 3D U-net dipole inversion. https://doi.org/10.1016/j.neuroimage.2018.06.030",
+    "QSMnet+ (deep learning; weights auto-downloaded) — QSMnet trained for a wider susceptibility range. https://doi.org/10.1016/j.neuroimage.2020.116579",
+    "AutoQSM (deep learning; weights auto-downloaded) — single-step reconstruction, no separate background removal. https://doi.org/10.1016/j.neuroimage.2019.116064",
+    "QSMGAN (deep learning; weights auto-downloaded) — GAN-refined U-net dipole inversion. https://doi.org/10.1016/j.neuroimage.2019.116389",
+    "IR2QSM (deep learning; weights auto-downloaded) — iterative unrolled U-net inversion. https://doi.org/10.1002/mp.17747",
+    "LPCNN (deep learning; weights auto-downloaded) — learned-proximal unrolled inversion. https://doi.org/10.1007/978-3-030-59713-9_13",
+    "MoDL-QSM (deep learning; weights auto-downloaded) — model-based unrolled inversion (χ33/STI). https://doi.org/10.1016/j.neuroimage.2021.118376",
+    "NeXtQSM (deep learning; weights auto-downloaded) — single-step reconstruction, no separate background removal. https://doi.org/10.1016/j.neuroimage.2022.119729",
+    "iQSM (deep learning; weights auto-downloaded) — end-to-end reconstruction from wrapped phase. https://doi.org/10.1016/j.neuroimage.2022.119410",
+    "iQSM+ (deep learning; weights auto-downloaded) — orientation-adaptive end-to-end reconstruction. https://doi.org/10.1016/j.media.2024.103160",
 ];
 const UNWRAP_HELP: &[&str] = &[
     "ROMEO region-growing unwrapping — https://doi.org/10.1002/mrm.28563",
@@ -970,6 +984,10 @@ pub struct PipelineFormState {
     // Parameters (as Strings for text editing)
     pub inhomogeneity_correction: bool,
     pub obliquity_threshold: String,
+
+    // Deep-learning overlap-tiling (empty = off / whole-volume). Shown for tileable DL inversions.
+    pub dl_tile_size: String,
+    pub dl_tile_halo: String,
 
     // RTS
     pub rts_delta: String,
@@ -1217,6 +1235,9 @@ pub struct PipelineFormState {
     pub editing: bool,
     pub cursor: usize,
     pub scroll_offset: usize,
+    /// Collapsed QSM-pipeline stage ids (see [`PipelineFormState::SECTION_IDS`]). Collapsed stages
+    /// show only their header + a one-line summary; expanded stages show their full controls.
+    pub collapsed_sections: std::collections::HashSet<&'static str>,
 
     // Mask ops editor state
     pub mask_ops_adding: bool,      // true when "Add step..." selector is active
@@ -1260,6 +1281,8 @@ impl Default for PipelineFormState {
             b0_weight_type: 0,   // phase_snr
             inhomogeneity_correction: true,
             obliquity_threshold: "-1".to_string(),
+            dl_tile_size: String::new(),
+            dl_tile_halo: String::new(),
             rts_delta: format!("{}", rts.delta),
             rts_mu: format!("{}", rts.mu),
             rts_tol: format!("{}", rts.tol),
@@ -1443,6 +1466,8 @@ impl Default for PipelineFormState {
             focus: 0,
             editing: false,
             cursor: 0,
+            // Start with every stage collapsed → the page opens as a compact pipeline overview.
+            collapsed_sections: Self::SECTION_IDS.iter().copied().collect(),
             scroll_offset: 0,
             mask_ops_adding: false,
             mask_ops_add_idx: 0,
@@ -1568,6 +1593,43 @@ impl PipelineFormState {
         rows
     }
 
+    /// Stable ids of the collapsible QSM-pipeline stages, top to bottom.
+    pub const SECTION_IDS: &[&'static str] =
+        &["general", "fieldmap", "masking", "bgremoval", "inversion", "reference"];
+
+    /// Build a stage header row, reading the current collapse state for `id`.
+    fn section_header(&self, id: &'static str, label: &'static str, summary: String) -> PipelineRow {
+        PipelineRow::SectionHeader {
+            id,
+            label,
+            summary,
+            collapsed: self.collapsed_sections.contains(id),
+        }
+    }
+
+    /// Toggle a stage's collapsed state.
+    pub fn toggle_section(&mut self, id: &'static str) {
+        if !self.collapsed_sections.remove(id) {
+            self.collapsed_sections.insert(id);
+        }
+    }
+
+    /// Drop the body rows of collapsed sections: keep every `SectionHeader`, and skip the rows
+    /// after a collapsed header until the next header. Rows before the first header are always kept.
+    fn apply_section_collapse(rows: Vec<PipelineRow>) -> Vec<PipelineRow> {
+        let mut out = Vec::with_capacity(rows.len());
+        let mut skipping = false;
+        for r in rows {
+            if let PipelineRow::SectionHeader { collapsed, .. } = &r {
+                skipping = *collapsed;
+                out.push(r);
+            } else if !skipping {
+                out.push(r);
+            }
+        }
+        out
+    }
+
     pub fn visible_rows(&self) -> Vec<PipelineRow> {
         if self.mode == PipelineTabMode::Separation {
             return self.separation_visible_rows();
@@ -1594,6 +1656,8 @@ impl PipelineFormState {
 
         // General settings (QSM-only)
         if self.do_qsm {
+        rows.push(self.section_header("general", "General",
+            format!("inhomogeneity correction {}", if self.inhomogeneity_correction { "on" } else { "off" })));
         rows.push(PipelineRow::Param {
             label: "Obliquity", field: "obliquity_threshold",
             help: "Resample oblique acquisitions to axial if obliquity exceeds this (degrees, -1 = disabled)",
@@ -1610,6 +1674,8 @@ impl PipelineFormState {
         // Field Mapping (hidden if TGV or QSMART)
         if !is_tgv && !is_qsmart && !is_iqsm {
             let is_laplacian = self.unwrapping_algorithm == 1;
+            rows.push(self.section_header("fieldmap", "Field mapping",
+                format!("{} unwrapping", UNWRAP_OPTIONS.get(self.unwrapping_algorithm).copied().unwrap_or(""))));
 
             // Phase offset removal (disabled for Laplacian)
             if !is_laplacian {
@@ -1669,6 +1735,8 @@ impl PipelineFormState {
         }
 
         // Mask preset selector (always visible — needed for SWI/T2*/R2* too)
+        rows.push(self.section_header("masking", "Masking",
+            MASK_PRESET_OPTIONS.get(self.get_select("mask_preset")).copied().unwrap_or("").to_string()));
         rows.push(PipelineRow::AlgoSelect {
             label: "Mask Preset", field: "mask_preset",
             options: MASK_PRESET_OPTIONS, help: MASK_PRESET_HELP,
@@ -1706,6 +1774,8 @@ impl PipelineFormState {
 
         // BG Removal (hidden for TGV, QSMART, MEDI+SMV, single-step DL, and end-to-end iQSM)
         if !is_tgv && !is_qsmart && !is_medi_smv && !is_single_step && !is_iqsm {
+            rows.push(self.section_header("bgremoval", "Background removal",
+                BF_OPTIONS.get(self.bf_algorithm).copied().unwrap_or("").to_string()));
             rows.push(PipelineRow::AlgoSelect {
                 label: "BG Removal", field: "bf_algorithm",
                 options: BF_OPTIONS, help: BF_HELP,
@@ -1762,6 +1832,8 @@ impl PipelineFormState {
         }
 
         // QSM Inversion
+        rows.push(self.section_header("inversion", "Dipole inversion",
+            QSM_ALGO_OPTIONS.get(self.qsm_algorithm).copied().unwrap_or("").to_string()));
         rows.push(PipelineRow::AlgoSelect {
             label: "QSM Inversion", field: "qsm_algorithm",
             options: QSM_ALGO_OPTIONS, help: QSM_ALGO_HELP,
@@ -1959,22 +2031,35 @@ impl PipelineFormState {
             _ => {}
         }
 
+        // Deep-learning overlap-tiling (optional). Shown for the tileable DL inversions; leave the
+        // fields blank to run whole-volume. Matched by name so it survives option reordering.
+        if matches!(
+            QSM_ALGO_OPTIONS.get(self.qsm_algorithm).copied().unwrap_or(""),
+            "xqsm" | "qsmnet" | "qsmnet-plus" | "ir2qsm" | "lpcnn" | "modl-qsm" | "nextqsm"
+        ) {
+            rows.push(PipelineRow::Param { label: "  Tile size", field: "dl_tile_size", help: "Overlap-tiling core size in voxels; set to run tiled (bounded memory, approximate). Blank = whole-volume." });
+            rows.push(PipelineRow::Param { label: "  Tile halo", field: "dl_tile_halo", help: "Overlap-tiling context margin in voxels (default 8 when tile size is set)." });
+        }
+
         rows.push(PipelineRow::Separator);
 
         // QSM Reference
+        rows.push(self.section_header("reference", "Referencing",
+            QSM_REF_OPTIONS.get(self.get_select("qsm_reference")).copied().unwrap_or("").to_string()));
         rows.push(PipelineRow::AlgoSelect {
             label: "QSM Reference", field: "qsm_reference",
             options: QSM_REF_OPTIONS, help: QSM_REF_HELP,
         });
         } // end if do_qsm (unwrapping/inversion/reference)
 
-        rows
+        Self::apply_section_collapse(rows)
     }
 
     /// All valid parameter field names, for testing that string dispatch is complete.
     #[cfg(test)]
     pub const ALL_PARAM_FIELDS: &[&str] = &[
         "obliquity_threshold",
+        "dl_tile_size", "dl_tile_halo",
         "rts_delta", "rts_mu", "rts_tol", "rts_rho", "rts_max_iter", "rts_lsmr_iter",
         "tv_lambda", "tv_rho", "tv_tol", "tv_max_iter",
         "tkd_threshold", "tsvd_threshold",
@@ -2008,6 +2093,8 @@ impl PipelineFormState {
     pub fn get_param(&self, field: &str) -> &str {
         match field {
             "obliquity_threshold" => &self.obliquity_threshold,
+            "dl_tile_size" => &self.dl_tile_size,
+            "dl_tile_halo" => &self.dl_tile_halo,
             "rts_delta" => &self.rts_delta,
             "rts_mu" => &self.rts_mu,
             "rts_tol" => &self.rts_tol,
@@ -2177,6 +2264,8 @@ impl PipelineFormState {
     pub fn get_param_mut(&mut self, field: &str) -> Option<&mut String> {
         match field {
             "obliquity_threshold" => Some(&mut self.obliquity_threshold),
+            "dl_tile_size" => Some(&mut self.dl_tile_size),
+            "dl_tile_halo" => Some(&mut self.dl_tile_halo),
             "rts_delta" => Some(&mut self.rts_delta),
             "rts_mu" => Some(&mut self.rts_mu),
             "rts_tol" => Some(&mut self.rts_tol),
@@ -4242,6 +4331,19 @@ impl App {
 
             // Interact
             KeyCode::Enter | KeyCode::Char(' ') => {
+                // A collapsible stage header toggles open/closed instead of opening a selector.
+                let section_id = {
+                    let ps = &self.pipeline_state;
+                    let focus_idx = ps.focusable_rows().get(ps.focus).copied().unwrap_or(0);
+                    match ps.visible_rows().get(focus_idx) {
+                        Some(PipelineRow::SectionHeader { id, .. }) => Some(*id),
+                        _ => None,
+                    }
+                };
+                if let Some(id) = section_id {
+                    self.pipeline_state.toggle_section(id);
+                    return;
+                }
                 // Single-choice selectors open a modal listing every option (rather than cycling).
                 let modal = {
                     let ps = &self.pipeline_state;
@@ -4442,6 +4544,15 @@ impl App {
                         }
                         Some(PipelineRow::MaskOpInput { section }) => {
                             ps.adjust_mask_input(*section, delta);
+                        }
+                        // Stage headers: ← collapses, → expands (in addition to Enter/Space toggle).
+                        Some(PipelineRow::SectionHeader { id, .. }) => {
+                            let id = *id;
+                            if delta < 0 {
+                                ps.collapsed_sections.insert(id);
+                            } else {
+                                ps.collapsed_sections.remove(id);
+                            }
                         }
                         _ => {}
                     }
@@ -4745,6 +4856,7 @@ mod tests {
     fn test_algo_modal_opens_on_enter_over_algoselect() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         app.pipeline_state.mode = PipelineTabMode::Qsm;
         // The QSM tab's first focusable row is the "Compute QSM" toggle; move to the inversion
         // AlgoSelect and open it.
@@ -4796,6 +4908,7 @@ mod tests {
     fn test_mask_input_modal_opens_and_sets() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         app.sync_pipeline_mode();
         // Focus the mask Input row.
         let rows = app.pipeline_state.visible_rows();
@@ -5082,6 +5195,7 @@ mod tests {
     fn test_filter_tab_routes_to_filter_handler() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         // Should not crash — filter handler takes over
         app.handle_key(key(KeyCode::Down));
         app.handle_key(key(KeyCode::Up));
@@ -5194,6 +5308,7 @@ mod tests {
     #[test]
     fn test_pipeline_visible_rows_change_with_algorithm() {
         let mut ps = super::PipelineFormState::default();
+        ps.collapsed_sections.clear(); // expand so algorithm-specific rows are visible
         let rows_rts = ps.visible_rows().len();
         ps.qsm_algorithm = 2; // TKD (fewer params)
         let rows_tkd = ps.visible_rows().len();
@@ -5202,6 +5317,47 @@ mod tests {
         ps.qsm_algorithm = 3; // TGV (hides unwrapping + bgremove)
         let rows_tgv = ps.visible_rows().len();
         assert!(rows_tgv < rows_rts, "TGV should hide unwrapping/bgremove");
+    }
+
+    #[test]
+    fn test_pipeline_section_collapse() {
+        let mut ps = super::PipelineFormState::default();
+        let has_param = |ps: &super::PipelineFormState, field: &str| {
+            ps.visible_rows().iter().any(|r| matches!(r, PipelineRow::Param { field: f, .. } if *f == field))
+        };
+        let has_header = |ps: &super::PipelineFormState, id: &str| {
+            ps.visible_rows().iter().any(|r| matches!(r, PipelineRow::SectionHeader { id: hid, .. } if *hid == id))
+        };
+        // Default is all-collapsed: headers present, bodies hidden.
+        assert!(has_header(&ps, "inversion"));
+        assert!(!has_param(&ps, "rts_delta"), "collapsed inversion should hide its params");
+        // Expanding shows the body; the header stays; collapsing hides it again.
+        ps.toggle_section("inversion");
+        assert!(has_param(&ps, "rts_delta"), "expanded inversion should show its params");
+        assert!(has_header(&ps, "inversion"), "header stays when expanded");
+        ps.toggle_section("inversion");
+        assert!(!has_param(&ps, "rts_delta"));
+    }
+
+    #[test]
+    fn test_pipeline_section_arrow_and_enter_toggle() {
+        let mut app = App::new();
+        app.active_tab = TAB_QSM; // (intentionally not clearing collapsed_sections: test the default)
+        // Focus the collapsed "inversion" header.
+        let rows = app.pipeline_state.visible_rows();
+        let focusable = app.pipeline_state.focusable_rows();
+        let hi = focusable.iter()
+            .position(|&ri| matches!(&rows[ri], PipelineRow::SectionHeader { id: "inversion", .. }))
+            .expect("inversion header present");
+        app.pipeline_state.focus = hi;
+        assert!(app.pipeline_state.collapsed_sections.contains("inversion"));
+        // → expands, ← collapses, Enter toggles.
+        app.handle_key(key(KeyCode::Right));
+        assert!(!app.pipeline_state.collapsed_sections.contains("inversion"), "→ should expand");
+        app.handle_key(key(KeyCode::Left));
+        assert!(app.pipeline_state.collapsed_sections.contains("inversion"), "← should collapse");
+        app.handle_key(key(KeyCode::Enter));
+        assert!(!app.pipeline_state.collapsed_sections.contains("inversion"), "Enter should toggle open");
     }
 
     // --- Filter tree tests ---
@@ -5337,9 +5493,14 @@ mod tests {
 
     #[test]
     fn test_all_param_fields_are_valid() {
+        // Opt-in fields that intentionally default to empty (blank = feature off).
+        const OPT_IN_EMPTY: &[&str] = &["dl_tile_size", "dl_tile_halo"];
         let state = PipelineFormState::default();
         for &field_name in PipelineFormState::ALL_PARAM_FIELDS {
             let val = state.get_param(field_name);
+            if OPT_IN_EMPTY.contains(&field_name) {
+                continue;
+            }
             assert_ne!(val, "", "get_param returned empty for field: {}", field_name);
         }
     }
@@ -5352,6 +5513,24 @@ mod tests {
                 state.get_param_mut(field_name).is_some(),
                 "get_param_mut returned None for field: {}", field_name,
             );
+        }
+    }
+
+    #[test]
+    fn test_algo_option_help_arrays_aligned() {
+        // Every selector's help array must have one entry per option, in order — otherwise the
+        // modal shows the wrong (or an empty) tooltip. Guards against silent drift.
+        use super::*;
+        for (label, opts, help) in [
+            ("qsm", QSM_ALGO_OPTIONS.len(), QSM_ALGO_HELP.len()),
+            ("separation", SEP_ALGO_OPTIONS.len(), SEP_ALGO_HELP.len()),
+            ("qsmart-inner", QSMART_INV_OPTIONS.len(), QSMART_INV_HELP.len()),
+            ("unwrap", UNWRAP_OPTIONS.len(), UNWRAP_HELP.len()),
+            ("bg-removal", BF_OPTIONS.len(), BF_HELP.len()),
+            ("qsm-reference", QSM_REF_OPTIONS.len(), QSM_REF_HELP.len()),
+            ("mask-preset", MASK_PRESET_OPTIONS.len(), MASK_PRESET_HELP.len()),
+        ] {
+            assert_eq!(opts, help, "{label}: {opts} options but {help} help entries");
         }
     }
 
@@ -5694,6 +5873,7 @@ mod tests {
     fn test_pipeline_tab_navigate_down_up() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         assert_eq!(app.pipeline_state.focus, 0);
         app.handle_key(key(KeyCode::Down));
         assert_eq!(app.pipeline_state.focus, 1);
@@ -5712,6 +5892,7 @@ mod tests {
     fn test_pipeline_tab_navigate_clamp_bottom() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         let max = app.pipeline_state.focusable_rows().len().saturating_sub(1);
         app.pipeline_state.focus = max;
         app.handle_key(key(KeyCode::Down));
@@ -5722,9 +5903,11 @@ mod tests {
     fn test_pipeline_tab_switch_from_pipeline() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         app.handle_key(key(KeyCode::Tab));
         assert_eq!(app.active_tab, 2);
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         app.handle_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT));
         assert_eq!(app.active_tab, 0);
     }
@@ -5733,6 +5916,7 @@ mod tests {
     fn test_pipeline_tab_number_switch() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         app.handle_key(key(KeyCode::Char('3')));
         assert_eq!(app.active_tab, 2);
     }
@@ -5742,6 +5926,7 @@ mod tests {
         let mut app = App::new();
         // Sit deep in the QSM tab, past the number of rows Separation will have.
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         app.sync_pipeline_mode();
         let qsm_max = app.pipeline_state.focusable_rows().len().saturating_sub(1);
         app.pipeline_state.focus = qsm_max;
@@ -5759,6 +5944,7 @@ mod tests {
     fn test_pipeline_left_right_algo_select() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         // Focus 0 is "Compute QSM" toggle, focus 1 is "Phase Combination" select
         // Find the focus index for the QSM Inversion AlgoSelect
         let rows = app.pipeline_state.visible_rows();
@@ -5783,6 +5969,7 @@ mod tests {
     fn test_pipeline_enter_opens_algo_modal_and_left_right_cycles() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         // Navigate to unwrapping_algorithm AlgoSelect
         let rows = app.pipeline_state.visible_rows();
         let focusable = app.pipeline_state.focusable_rows();
@@ -5820,6 +6007,7 @@ mod tests {
     fn test_pipeline_edit_text_param() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         // Find the obliquity_threshold Param row
         let rows = app.pipeline_state.visible_rows();
         let focusable = app.pipeline_state.focusable_rows();
@@ -5853,6 +6041,7 @@ mod tests {
     fn test_pipeline_toggle_do_qsm() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         // Focus 0 should be the do_qsm toggle
         app.pipeline_state.focus = 0;
         assert!(app.pipeline_state.do_qsm);
@@ -5867,6 +6056,7 @@ mod tests {
     fn test_pipeline_toggle_inhomogeneity_correction() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         // Find inhomogeneity_correction toggle
         let rows = app.pipeline_state.visible_rows();
         let focusable = app.pipeline_state.focusable_rows();
@@ -5888,6 +6078,7 @@ mod tests {
     fn test_pipeline_quit_from_pipeline_tab() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         app.handle_key(key(KeyCode::Char('q')));
         assert!(app.should_quit);
     }
@@ -5896,6 +6087,7 @@ mod tests {
     fn test_pipeline_esc_from_pipeline_tab() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         app.handle_key(key(KeyCode::Esc));
         assert!(app.should_quit);
     }
@@ -5904,6 +6096,7 @@ mod tests {
     fn test_pipeline_f5_from_pipeline_tab() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         app.form.bids_dir = "/tmp/bids".to_string();
         app.handle_key(key(KeyCode::F(5)));
         assert!(app.should_run);
@@ -5913,6 +6106,7 @@ mod tests {
     fn test_pipeline_reset_field() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         app.pipeline_state.qsm_algorithm = 5;
         // Find qsm_algorithm focus
         let rows = app.pipeline_state.visible_rows();
@@ -5934,6 +6128,7 @@ mod tests {
     fn test_pipeline_reset_tab() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         app.pipeline_state.qsm_algorithm = 5;
         app.pipeline_state.bf_algorithm = 3;
         app.handle_key(key(KeyCode::Char('R')));
@@ -5954,6 +6149,7 @@ mod tests {
     fn test_pipeline_editing_left_right_cursor() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         // Find obliquity_threshold param and edit it
         let rows = app.pipeline_state.visible_rows();
         let focusable = app.pipeline_state.focusable_rows();
@@ -7053,6 +7249,7 @@ mod tests {
     fn test_pipeline_mask_preset_switch() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         // Find mask_preset focus
         let rows = app.pipeline_state.visible_rows();
         let focusable = app.pipeline_state.focusable_rows();
@@ -7075,6 +7272,7 @@ mod tests {
         use crate::pipeline::config::{MaskOp, MaskThresholdMethod};
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         app.sync_pipeline_mode();
         // Default preset is a threshold generator, so the param row is the method select.
         assert!(matches!(
@@ -7106,6 +7304,7 @@ mod tests {
         use crate::pipeline::config::MaskOp;
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         app.sync_pipeline_mode();
         // Switch the generator to BET so the param row is a numeric frac-intensity slider.
         app.pipeline_state.mask_sections[0].generator = MaskOp::Bet { fractional_intensity: 0.5 };
@@ -7123,6 +7322,7 @@ mod tests {
     fn test_pipeline_mask_add_section() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         let initial_sections = app.pipeline_state.mask_sections.len();
         // Find MaskOpAddSection focus
         let rows = app.pipeline_state.visible_rows();
@@ -7144,6 +7344,7 @@ mod tests {
     fn test_pipeline_mask_add_step() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         let initial_refs = app.pipeline_state.mask_sections[0].refinements.len();
         // Find MaskOpAddStep for section 0
         let rows = app.pipeline_state.visible_rows();
@@ -7170,6 +7371,7 @@ mod tests {
     fn test_pipeline_mask_add_step_cycle_ops() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         let rows = app.pipeline_state.visible_rows();
         let focusable = app.pipeline_state.focusable_rows();
         let mut add_step_focus = None;
@@ -7197,6 +7399,7 @@ mod tests {
     fn test_pipeline_mask_delete_refinement() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         let initial_refs = app.pipeline_state.mask_sections[0].refinements.len();
         assert!(initial_refs > 0);
         // Find first MaskOpEntry focus
@@ -7219,6 +7422,7 @@ mod tests {
     fn test_pipeline_mask_adjust_op_left_right() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         // Find MaskOpEntry focus and adjust with Left/Right
         let rows = app.pipeline_state.visible_rows();
         let focusable = app.pipeline_state.focusable_rows();
@@ -7240,6 +7444,7 @@ mod tests {
     fn test_pipeline_mask_generator_adjust() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         // Find MaskOpGenerator focus
         let rows = app.pipeline_state.visible_rows();
         let focusable = app.pipeline_state.focusable_rows();
@@ -7269,6 +7474,7 @@ mod tests {
     fn test_pipeline_mask_generator_param_adjust() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         // Find MaskOpGeneratorParam focus
         let rows = app.pipeline_state.visible_rows();
         let focusable = app.pipeline_state.focusable_rows();
@@ -7293,6 +7499,7 @@ mod tests {
     fn test_pipeline_mask_input_adjust() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         // Find MaskOpInput focus
         let rows = app.pipeline_state.visible_rows();
         let focusable = app.pipeline_state.focusable_rows();
@@ -7346,6 +7553,7 @@ mod tests {
     fn test_reset_pipeline_param_field() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         // Find obliquity_threshold param
         let rows = app.pipeline_state.visible_rows();
         let focusable = app.pipeline_state.focusable_rows();
@@ -7374,6 +7582,7 @@ mod tests {
     fn test_reset_pipeline_toggle_field() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         // Focus 0 is do_qsm toggle
         app.pipeline_state.focus = 0;
         app.pipeline_state.do_qsm = false;
@@ -7492,6 +7701,7 @@ mod tests {
     fn test_pipeline_threshold_value_editing() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         // Set generator to Fixed threshold to make MaskOpThresholdValue visible
         app.pipeline_state.mask_sections[0].generator = crate::pipeline::config::MaskOp::Threshold {
             method: crate::pipeline::config::MaskThresholdMethod::Fixed,
@@ -7537,6 +7747,7 @@ mod tests {
     fn test_pipeline_threshold_value_esc_cancels() {
         let mut app = App::new();
         app.active_tab = TAB_QSM;
+        app.pipeline_state.collapsed_sections.clear();
         app.pipeline_state.mask_sections[0].generator = crate::pipeline::config::MaskOp::Threshold {
             method: crate::pipeline::config::MaskThresholdMethod::Fixed,
             value: Some(0.5),

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -440,6 +440,10 @@ pub fn build_run_args(app: &App) -> crate::Result<RunArgs> {
             swi_strength: parse_optional_f64(&form.swi_strength),
             swi_mip_window: parse_optional_usize(&form.swi_mip_window),
         },
+        tiling_params: crate::cli::TilingParamArgs {
+            tile_size: parse_optional_usize(&ps.dl_tile_size),
+            tile_halo: parse_optional_usize(&ps.dl_tile_halo),
+        },
         n_procs: parse_optional_usize(&form.n_procs),
         homogeneity_sigma_mm: None,
         homogeneity_nbox: None,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -52,12 +52,24 @@ fn centered_rect(w: u16, h: u16, area: Rect) -> Rect {
 /// Pop-up list to choose one algorithm option, showing every option at once (scrolls if needed)
 /// plus the highlighted option's help.
 fn draw_algo_modal(f: &mut Frame, modal: &AlgoModal, area: Rect) {
-    // Width: fit the longest option/title; height: options + help + borders + hint.
+    // Cap the visible list rather than growing to fit every option — a long list (e.g. the 29 QSM
+    // algorithms) then scrolls (with a scrollbar) instead of overflowing the screen and pushing
+    // the tooltip/hotkey footer off the bottom. Reserve room for a 3-line wrapped tooltip + a
+    // 1-line footer, and go wide so those lines fit.
+    const MAX_LIST_ROWS: u16 = 14;
+    const HELP_ROWS: u16 = 3;
+    const FOOTER_ROWS: u16 = 1;
+    let chrome = 2 + HELP_ROWS + FOOTER_ROWS; // borders + tooltip + footer
+
     let content_w = modal.options.iter().map(|o| o.len()).max().unwrap_or(0)
         .max(modal.title.len()) as u16 + 8;
-    let width = content_w.clamp(30, 70).min(area.width.saturating_sub(4));
-    let list_h = (modal.options.len() as u16).min(area.height.saturating_sub(10)).max(1);
-    let height = list_h + 6; // borders(2) + help(2) + hint(1) + list
+    // Wide enough for the footer legend and long tooltips (which still wrap); clamp to screen.
+    let width = content_w.max(72).clamp(72, 100).min(area.width.saturating_sub(4)).max(30);
+    let list_h = (modal.options.len() as u16)
+        .min(MAX_LIST_ROWS)
+        .min(area.height.saturating_sub(chrome + 2)) // keep the whole modal on-screen
+        .max(1);
+    let height = (list_h + chrome).min(area.height.saturating_sub(2));
     let popup = centered_rect(width, height, area);
 
     f.render_widget(Clear, popup);
@@ -70,16 +82,51 @@ fn draw_algo_modal(f: &mut Frame, modal: &AlgoModal, area: Rect) {
 
     let parts = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(2), Constraint::Length(1)])
+        .constraints([
+            Constraint::Min(1),
+            Constraint::Length(HELP_ROWS),
+            Constraint::Length(FOOTER_ROWS),
+        ])
         .split(inner);
 
-    let items: Vec<ListItem> = modal.options.iter().map(|o| ListItem::new(o.clone())).collect();
+    // Colour deep-learning options distinctly so they read as a group (they are listed
+    // contiguously at the end of each algorithm modal).
+    let dl_color = Color::LightMagenta;
+    let has_dl = modal.options.iter().any(|o| is_deep_learning_algo(o));
+    let items: Vec<ListItem> = modal.options.iter().map(|o| {
+        let item = ListItem::new(o.clone());
+        if is_deep_learning_algo(o) { item.style(Style::default().fg(dl_color)) } else { item }
+    }).collect();
+
+    // Reserve a 1-column scrollbar gutter when the list overflows its viewport.
+    let needs_scroll = modal.options.len() > parts[0].height as usize;
+    let (list_area, sb_area) = if needs_scroll {
+        let cols = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Min(1), Constraint::Length(1)])
+            .split(parts[0]);
+        (cols[0], Some(cols[1]))
+    } else {
+        (parts[0], None)
+    };
+
     let list = List::new(items)
         .highlight_style(Style::default().fg(Color::Black).bg(Color::Cyan).add_modifier(Modifier::BOLD))
         .highlight_symbol("▶ ");
     let mut state = ListState::default();
     state.select(Some(modal.cursor));
-    f.render_stateful_widget(list, parts[0], &mut state);
+    f.render_stateful_widget(list, list_area, &mut state);
+
+    if let Some(sb_area) = sb_area {
+        let mut sb_state = ScrollbarState::new(modal.options.len())
+            .viewport_content_length(list_area.height as usize)
+            .position(modal.cursor);
+        let sb = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(None)
+            .end_symbol(None)
+            .thumb_style(Style::default().fg(Color::Cyan));
+        f.render_stateful_widget(sb, sb_area, &mut sb_state);
+    }
 
     let help = modal.help.get(modal.cursor).cloned().unwrap_or_default();
     f.render_widget(
@@ -88,17 +135,30 @@ fn draw_algo_modal(f: &mut Frame, modal: &AlgoModal, area: Rect) {
             .wrap(Wrap { trim: true }),
         parts[1],
     );
-    f.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("↑↓", Style::default().fg(Color::Yellow)),
-            Span::styled(" select  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Enter", Style::default().fg(Color::Yellow)),
-            Span::styled(" choose  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Esc", Style::default().fg(Color::Yellow)),
-            Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
-        ])),
-        parts[2],
-    );
+    let mut footer = vec![
+        Span::styled("↑↓", Style::default().fg(Color::Yellow)),
+        Span::styled(" select  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Enter", Style::default().fg(Color::Yellow)),
+        Span::styled(" choose  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Esc", Style::default().fg(Color::Yellow)),
+        Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+    ];
+    if has_dl {
+        footer.push(Span::styled("   ◆", Style::default().fg(dl_color)));
+        footer.push(Span::styled(" deep learning", Style::default().fg(Color::DarkGray)));
+    }
+    f.render_widget(Paragraph::new(Line::from(footer)), parts[2]);
+}
+
+/// Deep-learning algorithm ids across the inversion / background-removal / separation modals.
+/// Used to colour them as a group in the selector.
+fn is_deep_learning_algo(name: &str) -> bool {
+    matches!(
+        name,
+        "xqsm" | "qsmnet" | "qsmnet-plus" | "autoqsm" | "qsmgan" | "ir2qsm" | "lpcnn"
+            | "modl-qsm" | "nextqsm" | "iqsm" | "iqsm-plus" | "bfrnet" | "iqfm"
+            | "susep-net" | "chi-sepnet"
+    )
 }
 
 /// Render a scrollable paragraph with a scrollbar when content exceeds visible height.
@@ -1223,6 +1283,27 @@ fn draw_pipeline_tab(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) 
                 format!("  {}", text),
                 Style::default().fg(Color::Yellow),
             )),
+            PipelineRow::SectionHeader { id: _, label, summary, collapsed } => {
+                if focused {
+                    focused_help = Some(if *collapsed {
+                        "Enter/Space/→ to expand this section".to_string()
+                    } else {
+                        "Enter/Space/← to collapse this section".to_string()
+                    });
+                }
+                let arrow = if *collapsed { "▸" } else { "▾" };
+                let header_style = if focused {
+                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+                };
+                // Headers sit at column 0 (params are indented) so they read as section dividers.
+                let mut spans = vec![Span::styled(format!("{} {}", arrow, label), header_style)];
+                if *collapsed && !summary.is_empty() {
+                    spans.push(Span::styled(format!("  ·  {}", summary), Style::default().fg(Color::DarkGray)));
+                }
+                Line::from(spans)
+            }
             PipelineRow::MaskSectionHeader { section } => {
                 Line::from(Span::styled(
                     format!("  ── Mask {} ──", section + 1),
@@ -1447,8 +1528,15 @@ fn draw_pipeline_tab(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) 
         if let Some(&row_idx) = focusable.get(ps_focus) {
             if row_idx >= scroll && row_idx < scroll + form_area.height as usize {
                 let y = form_area.y + (row_idx - scroll) as u16;
-                let label_width = 24;
-                let x = form_area.x + label_width + ps_cursor as u16;
+                // The value starts after the 2-char row indent + the label field, which the render
+                // left-pads to a *minimum* of 22 columns (`format!("  {:22}", "label:")`) but lets
+                // grow for longer labels — so a wide label (e.g. the relaxometry constants) pushes
+                // the value right. Match that here instead of assuming a fixed 24.
+                let label_cols = match rows.get(row_idx) {
+                    Some(PipelineRow::Param { label, .. }) => (label.chars().count() + 1).max(22),
+                    _ => 22,
+                };
+                let x = form_area.x + 2 + label_cols as u16 + ps_cursor as u16;
                 f.set_cursor_position((x, y));
             }
         }
@@ -1622,6 +1710,34 @@ mod tests {
     fn test_draw_default_app_no_panic() {
         let mut app = App::new();
         let _ = render_app(&mut app);
+    }
+
+    #[test]
+    fn test_algo_modal_scrollbar_and_legend() {
+        use crate::tui::app::AlgoModalTarget;
+        let mut app = App::new();
+        // A long list with deep-learning entries at the end (like the QSM inversion selector).
+        let mut options: Vec<String> = (0..18).map(|i| format!("classical-{i}")).collect();
+        options.extend(["xqsm", "qsmnet", "autoqsm", "nextqsm"].iter().map(|s| s.to_string()));
+        let help: Vec<String> = options.iter().map(|o| format!("help for {o}")).collect();
+        app.algo_modal = Some(AlgoModal {
+            target: AlgoModalTarget::PipelineSelect("qsm_algorithm".into()),
+            title: "QSM Inversion".into(),
+            options,
+            help,
+            cursor: 20, // inside the DL group, past the capped viewport → list must scroll
+        });
+        let term = render_app(&mut app);
+        let buf = term.backend().buffer();
+        let mut text = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                text.push_str(buf[(x, y)].symbol());
+            }
+        }
+        assert!(text.contains('█'), "expected a scrollbar thumb in the overflowing modal");
+        assert!(text.contains("deep learning"), "expected the deep-learning legend in the footer");
+        assert!(text.contains("select") && text.contains("cancel"), "expected the hotkey footer");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Pins **qsm-core v0.28.0** (overlap-tiled DL inference + Hugging Face CORS weight hosting) and surfaces tiling across the CLI, TUI, and `qsmxt-config`, plus a round of TUI navigation/UX polish. Second of the three-repo release chain (QSM.rs #71 → **this** → qsmbly).

### Deep-learning overlap-tiling (opt-in)
Runs the DL dipole inversions patch-by-patch to bound memory. **Default is whole-volume** — presence of `--tile-size` enables it.
- **CLI**: `--tile-size` / `--tile-halo` on `qsmxt run` and `qsmxt invert`.
- **qsmxt-config**: `InversionConfig.tile_size`/`tile_halo`; emits the flags in the generated command (tileable DL algos only) and notes tiling in the methods text; bridges to qsm-core's `InversionConfig.tile`.
- **memory estimate**: bounded by one patch when tiling is on.

### TUI
- **Tiling rows** (Tile size / Tile halo) shown for tileable DL inversions, wired into the generated command.
- **Collapsible pipeline stages** — the QSM tab opens as a compact overview (one line per stage with a summary of the current choice); Enter/Space or ←/→ toggles. Directly addresses the "too much to scroll through" problem.
- **Modal polish** — scrollbar on overflow, wider/shorter sizing so the tooltip + hotkeys fit, deep-learning options grouped/coloured with a legend, and a **rebuilt, aligned help array** (fixes wrong/missing algorithm tooltips) guarded by a length test.
- **Fix** — relaxometry-constant field cursor now lands at the value (computed from the actual label width, not a hardcoded column).

## Testing
- Builds clean against the released qsm-core v0.28.0 (no local patch).
- `cargo test`: 549 pass (includes new tiling command/methods tests, a modal scrollbar render test, help-array alignment guard, and collapse behaviour tests).

## Release chain
On merge + release, this deploys the updated `qsmxt-config`; qsmbly then repins it (final step). OSF weights can be removed once this is adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)