### PR TITLE
chore: bump qsm-core to v0.29.0 (MEDI radian-scale default λ)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "qsm-core"
 version = "0.0.0"
-source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.28.0#ff0c2887d52ecec0509365b6ded5b4c0ea07edac"
+source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.29.0#beb7f4defa0f9949b5114d6ab15e5c2bdb1f60aa"
 dependencies = [
  "bytemuck",
  "delaunator",
@@ -3634,7 +3634,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = ["dl"]
 dl = ["qsm-core/onnx", "qsm-core/download"]
 
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.28.0", features = ["parallel"] }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.29.0", features = ["parallel"] }
 qsmxt-config = { path = "crates/qsmxt-config" }
 clap = { version = "4", features = ["derive"] }
 const_format = "0.2"

--- a/crates/qsmxt-config/Cargo.toml
+++ b/crates/qsmxt-config/Cargo.toml
@@ -6,7 +6,7 @@ description = "Pipeline configuration, command generation, and methods text for 
 license = "GPL-3.0-only"
 
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.28.0" }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.29.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"


### PR DESCRIPTION
Picks up qsm-core v0.29.0: MEDI default λ 7.5e-5→1e-3, tuned at the radian field scale `invert medi` feeds the solver. Fixes the under-regularized streaking on QSM-CI's MEDI (QSM.rs) maps; matches Cornell MEDI smoothness on in-vivo data. Verified `cargo check --workspace` against v0.29.0.

Next: tag release v9.16.0 so the QSM-CI `_qsmxt` image can pin it.