### PR TITLE
chore: bump qsm-core to v0.30.0 (AMP-PE divergence fix, V-SHARP threshold)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1381,7 +1381,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "qsm-core"
 version = "0.0.0"
-source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.29.0#beb7f4defa0f9949b5114d6ab15e5c2bdb1f60aa"
+source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.30.0#dd685ab07b73cec7160eef010a11253e1f4e35cb"
 dependencies = [
  "bytemuck",
  "delaunator",
@@ -2595,7 +2595,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2996,7 +2996,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3006,7 +3006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3634,7 +3634,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = ["dl"]
 dl = ["qsm-core/onnx", "qsm-core/download"]
 
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.29.0", features = ["parallel"] }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.30.0", features = ["parallel"] }
 qsmxt-config = { path = "crates/qsmxt-config" }
 clap = { version = "4", features = ["derive"] }
 const_format = "0.2"

--- a/crates/qsmxt-config/Cargo.toml
+++ b/crates/qsmxt-config/Cargo.toml
@@ -6,7 +6,7 @@ description = "Pipeline configuration, command generation, and methods text for 
 license = "GPL-3.0-only"
 
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.29.0" }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.30.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"


### PR DESCRIPTION
Picks up [QSM.rs v0.30.0](https://github.com/astewartau/QSM.rs/releases/tag/v0.30.0), which carries two behaviour changes.

## AMP-PE: adaptive damping

AMP-PE could diverge outright on in-vivo local fields, with χ growing without bound to ~1e34 — **58.7% of runs** on the QSM-CI harmonization set, while every other dipole method was 0/14,074. Long-standing rather than new: the MATLAB reference is unstable the same way.

The magnitude-derived wavelet morphology prior destabilises the GAMP iteration. It now measures the data fit each sweep, rejects a diverging one (restore last good state, halve damping, retry), and **ratchets the damping ceiling down** so it never climbs back to a rate that already diverged.

**Inert where nothing diverges** — a fixed synthetic problem gives a bitwise-identical output hash against v0.29.0, and a real 1.6M-voxel non-diverging acquisition reproduces to every reported digit. On the real failing case: sd `1.35e34 → 0.0540` at the default iteration count.

## V-SHARP: default threshold 0.05 → 0.2

The old default under-regularised the TSVD deconvolution and amplified field-mapping error on the *estimated* fields every real pipeline feeds it. Inert on a clean field; lowers composed NRMSE on every dipole tested on the QSM Challenge 2.0 phantom.

**This changes V-SHARP output for anyone relying on the default.** Callers passing an explicit `threshold` are unaffected.

## Both pins move together

`qsm-core` is declared in **two** places here:

```
Cargo.toml                      qsm-core v0.29.0 → v0.30.0
crates/qsmxt-config/Cargo.toml  qsm-core v0.29.0 → v0.30.0
```

Bumping only the root leaves **two copies** of `qsm-core` in the lockfile. `qsmxt-config` is also what QSMbly consumes, so keeping them in step is what lets QSMbly resolve a single copy once it points at this tag.

## Verification

- Confirmed the pinned source actually contains both changes (`damp_ceiling` present, V-SHARP default `0.2`) rather than just a changed tag string
- Lockfile down to a single `qsm-core` entry at v0.30.0
- `cargo build --release` clean; **558 tests pass, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)