### PR TITLE
Fix SLURM mode ignoring the configured pipeline

### DIFF
--- a/docs/src/content/docs/guides/running-noninteractively.md
+++ b/docs/src/content/docs/guides/running-noninteractively.md
@@ -201,6 +201,19 @@ This produces SLURM batch scripts for your dataset that you can submit with
 to a local run — just distributed. Run `qsmxt slurm --help` for the available
 options (partition, time limits, resource requests, and run selection).
 
+`qsmxt slurm` accepts the same pipeline options as `qsmxt run` (algorithms,
+masking, per-algorithm parameters, `--config`, …), so any `qsmxt run` command
+becomes a SLURM one by swapping the subcommand and adding the scheduler flags:
+
+```sh
+qsmxt slurm study/bids --qsm-algorithm tgv --unwrapping-algorithm laplacian \
+  --account myaccount --time 04:00:00
+```
+
+The resolved pipeline is written to
+`<OUTPUT_DIR>/derivatives/qsmxt/pipeline_config.toml` and each generated job
+runs against that file.
+
 :::note
 SLURM submission is available in the [TUI](/QSMxT/guides/running-interactively/)
 too — you don't have to use the command line to scale out.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -844,30 +844,13 @@ pub struct SwiParamArgs {
 
 // ─── Pipeline commands ───
 
-#[derive(Parser, Debug)]
-pub struct RunArgs {
-    /// Input BIDS directory
-    pub bids_dir: PathBuf,
-
-    /// Output directory (defaults to bids_dir; outputs go into <dir>/derivatives/qsmxt/)
-    pub output_dir: Option<PathBuf>,
-
-    /// Pipeline configuration file (TOML)
-    #[arg(long)]
-    pub config: Option<PathBuf>,
-
-    /// Include only runs matching these glob patterns (e.g. "sub-1*" "*ses-pre*")
-    #[arg(long, num_args = 1..)]
-    pub include: Option<Vec<String>>,
-
-    /// Exclude runs matching these glob patterns (e.g. "*mygrea*")
-    #[arg(long, num_args = 1..)]
-    pub exclude: Option<Vec<String>>,
-
-    /// Limit number of echoes to process
-    #[arg(long)]
-    pub num_echoes: Option<usize>,
-
+/// Pipeline configuration overrides shared by `qsmxt run` and `qsmxt slurm`.
+///
+/// These map onto `PipelineConfig` fields via `apply_run_overrides()`; both
+/// subcommands flatten this struct so a pipeline configured once (in the TUI or
+/// on the command line) means the same thing whether it runs locally or on SLURM.
+#[derive(Args, Debug, Default)]
+pub struct PipelineArgs {
     /// QSM algorithm
     #[arg(long, value_enum)]
     pub qsm_algorithm: Option<QsmAlgorithmArg>,
@@ -990,11 +973,6 @@ pub struct RunArgs {
     #[command(flatten)]
     pub tiling_params: TilingParamArgs,
 
-
-    /// Number of parallel threads
-    #[arg(long)]
-    pub n_procs: Option<usize>,
-
     /// Inhomogeneity correction smoothing sigma in mm
     #[arg(long)]
     pub homogeneity_sigma_mm: Option<f64>,
@@ -1059,18 +1037,6 @@ pub struct RunArgs {
     #[arg(long)]
     pub export_dicom: bool,
 
-    /// Optional source DICOM directory; inherit patient/study identity from the
-    /// original DICOMs when exporting (used with --export-dicom)
-    #[arg(long)]
-    pub source_dicom: Option<PathBuf>,
-
-    /// Restrict DICOM export to these maps (default: all produced). Values:
-    /// chimap, swi, minip, t2starmap, r2starmap, r2map, r2primemap,
-    /// desc-paramagnetic_chimap, desc-diamagnetic_chimap, desc-total_chimap
-    /// (used with --export-dicom)
-    #[arg(long, num_args = 1.., value_delimiter = ',')]
-    pub dicom_outputs: Option<Vec<String>>,
-
     /// Apply inhomogeneity correction to magnitude before masking
     #[arg(long)]
     pub inhomogeneity_correction: bool,
@@ -1099,6 +1065,50 @@ pub struct RunArgs {
     /// Example: magnitude,bet:0.5,erode:2
     #[arg(long = "mask", num_args = 1)]
     pub mask_sections_cli: Option<Vec<String>>,
+}
+
+#[derive(Parser, Debug)]
+pub struct RunArgs {
+    /// Input BIDS directory
+    pub bids_dir: PathBuf,
+
+    /// Output directory (defaults to bids_dir; outputs go into <dir>/derivatives/qsmxt/)
+    pub output_dir: Option<PathBuf>,
+
+    /// Pipeline configuration file (TOML)
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+
+    /// Include only runs matching these glob patterns (e.g. "sub-1*" "*ses-pre*")
+    #[arg(long, num_args = 1..)]
+    pub include: Option<Vec<String>>,
+
+    /// Exclude runs matching these glob patterns (e.g. "*mygrea*")
+    #[arg(long, num_args = 1..)]
+    pub exclude: Option<Vec<String>>,
+
+    /// Limit number of echoes to process
+    #[arg(long)]
+    pub num_echoes: Option<usize>,
+
+    #[command(flatten)]
+    pub pipeline: PipelineArgs,
+
+    /// Number of parallel threads
+    #[arg(long)]
+    pub n_procs: Option<usize>,
+
+    /// Optional source DICOM directory; inherit patient/study identity from the
+    /// original DICOMs when exporting (used with --export-dicom)
+    #[arg(long)]
+    pub source_dicom: Option<PathBuf>,
+
+    /// Restrict DICOM export to these maps (default: all produced). Values:
+    /// chimap, swi, minip, t2starmap, r2starmap, r2map, r2primemap,
+    /// desc-paramagnetic_chimap, desc-diamagnetic_chimap, desc-total_chimap
+    /// (used with --export-dicom)
+    #[arg(long, num_args = 1.., value_delimiter = ',')]
+    pub dicom_outputs: Option<Vec<String>>,
 
     /// Print processing plan without executing
     #[arg(long)]
@@ -1193,6 +1203,9 @@ pub struct SlurmArgs {
     /// Limit number of echoes to process
     #[arg(long)]
     pub num_echoes: Option<usize>,
+
+    #[command(flatten)]
+    pub pipeline: PipelineArgs,
 }
 
 // ─── Standalone algorithm commands (subcommand-per-algorithm) ───

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -35,82 +35,84 @@ mod integration_tests {
             include: None,
             exclude: None,
             num_echoes: None,
-            qsm_algorithm: None,
-            unwrapping_algorithm: None,
-            bf_algorithm: None,
-            masking_input: None,
-            phase_offset_removal: None,
-            phase_offset_sigma: None,
-            bipolar_correction: false,
-            b0_estimation: None,
-            b0_weight_type: None,
-            bet_fractional_intensity: None,
-            bet_smoothness: None,
-            bet_gradient_threshold: None,
-            bet_iterations: None,
-            bet_subdivisions: None,
-            qsm_reference: None,
-            rts_params: Default::default(),
-            tv_params: Default::default(),
-            tkd_params: Default::default(),
-            tsvd_params: Default::default(),
-            tgv_params: Default::default(),
-            tikhonov_params: Default::default(),
-            nltv_params: Default::default(),
-            medi_params: Default::default(),
-            tfi_params: Default::default(),
-            ilsqr_params: Default::default(),
-            qsmart_params: Default::default(),
-            ndi_params: Default::default(),
-            fansi_params: Default::default(),
-            l1qsm_params: Default::default(),
-            whqsm_params: Default::default(),
-            hdqsm_params: Default::default(),
-            amp_pe_params: Default::default(),
-            separation_params: Default::default(),
-            vsharp_params: Default::default(),
-            pdf_params: Default::default(),
-            lbv_params: Default::default(),
-            ismv_params: Default::default(),
-            sharp_params: Default::default(),
-            resharp_params: Default::default(),
-            harperella_params: Default::default(),
-            iharperella_params: Default::default(),
-            msmv_params: Default::default(),
-            romeo_params: Default::default(),
-            swi_params: Default::default(),
-            tiling_params: Default::default(),
             n_procs: Some(1),
-            homogeneity_sigma_mm: None,
-            homogeneity_nbox: None,
-            linear_fit_reliability_threshold: None,
-            linear_fit_estimate_offset: None,
-            no_qsm: false,
-            do_swi: false,
-            do_t2starmap: false,
-            do_r2starmap: false,
-            do_r2map: false,
-            do_r2primemap: false,
-            do_chi_separation: false,
-            chi_separation_algorithm: None,
-            use_custom_qsm: None,
-            use_custom_r2: None,
-            use_custom_r2prime: None,
-            export_dicom: false,
             source_dicom: None,
             dicom_outputs: None,
-            inhomogeneity_correction: false,
-            no_inhomogeneity_correction: false,
-            obliquity_threshold: None,
-            mask_preset: None,
-            use_custom_masks: None,
-            mask_sections_cli: None,
             dry: true,
             debug: false,
             mem_limit_gb: None,
             no_mem_limit: false,
             force: false,
             clean_intermediates: false,
+            pipeline: PipelineArgs {
+                qsm_algorithm: None,
+                unwrapping_algorithm: None,
+                bf_algorithm: None,
+                masking_input: None,
+                phase_offset_removal: None,
+                phase_offset_sigma: None,
+                bipolar_correction: false,
+                b0_estimation: None,
+                b0_weight_type: None,
+                bet_fractional_intensity: None,
+                bet_smoothness: None,
+                bet_gradient_threshold: None,
+                bet_iterations: None,
+                bet_subdivisions: None,
+                qsm_reference: None,
+                rts_params: Default::default(),
+                tv_params: Default::default(),
+                tkd_params: Default::default(),
+                tsvd_params: Default::default(),
+                tgv_params: Default::default(),
+                tikhonov_params: Default::default(),
+                nltv_params: Default::default(),
+                medi_params: Default::default(),
+                tfi_params: Default::default(),
+                ilsqr_params: Default::default(),
+                qsmart_params: Default::default(),
+                ndi_params: Default::default(),
+                fansi_params: Default::default(),
+                l1qsm_params: Default::default(),
+                whqsm_params: Default::default(),
+                hdqsm_params: Default::default(),
+                amp_pe_params: Default::default(),
+                separation_params: Default::default(),
+                vsharp_params: Default::default(),
+                pdf_params: Default::default(),
+                lbv_params: Default::default(),
+                ismv_params: Default::default(),
+                sharp_params: Default::default(),
+                resharp_params: Default::default(),
+                harperella_params: Default::default(),
+                iharperella_params: Default::default(),
+                msmv_params: Default::default(),
+                romeo_params: Default::default(),
+                swi_params: Default::default(),
+                tiling_params: Default::default(),
+                homogeneity_sigma_mm: None,
+                homogeneity_nbox: None,
+                linear_fit_reliability_threshold: None,
+                linear_fit_estimate_offset: None,
+                no_qsm: false,
+                do_swi: false,
+                do_t2starmap: false,
+                do_r2starmap: false,
+                do_r2map: false,
+                do_r2primemap: false,
+                do_chi_separation: false,
+                chi_separation_algorithm: None,
+                use_custom_qsm: None,
+                use_custom_r2: None,
+                use_custom_r2prime: None,
+                export_dicom: false,
+                inhomogeneity_correction: false,
+                no_inhomogeneity_correction: false,
+                obliquity_threshold: None,
+                mask_preset: None,
+                use_custom_masks: None,
+                mask_sections_cli: None,
+            },
         }
     }
 
@@ -603,7 +605,7 @@ mod integration_tests {
         testutils::create_multi_echo_bids(&bids);
 
         let mut args = default_run_args(bids, out);
-        args.qsm_algorithm = Some(QsmAlgorithmArg::Tkd);
+        args.pipeline.qsm_algorithm = Some(QsmAlgorithmArg::Tkd);
         args.no_mem_limit = true;
         super::run::execute(args).unwrap();
     }
@@ -625,10 +627,10 @@ mod integration_tests {
         testutils::create_single_echo_bids(&bids);
 
         let mut args = default_run_args(bids, out.clone());
-        args.qsm_algorithm = Some(QsmAlgorithmArg::Tkd);
-        args.unwrapping_algorithm = Some(UnwrapAlgorithmArg::Laplacian);
-        args.bf_algorithm = Some(BfAlgorithmArg::Vsharp);
-        args.masking_input = Some(MaskInputArg::MagnitudeFirst);
+        args.pipeline.qsm_algorithm = Some(QsmAlgorithmArg::Tkd);
+        args.pipeline.unwrapping_algorithm = Some(UnwrapAlgorithmArg::Laplacian);
+        args.pipeline.bf_algorithm = Some(BfAlgorithmArg::Vsharp);
+        args.pipeline.masking_input = Some(MaskInputArg::MagnitudeFirst);
         args.dry = false;
         args.no_mem_limit = true;
         super::run::execute(args).unwrap();
@@ -676,10 +678,10 @@ mod integration_tests {
 
         let make_args = || {
             let mut args = default_run_args(bids.clone(), out.clone());
-            args.qsm_algorithm = Some(QsmAlgorithmArg::Tkd);
-            args.unwrapping_algorithm = Some(UnwrapAlgorithmArg::Laplacian);
-            args.bf_algorithm = Some(BfAlgorithmArg::Vsharp);
-            args.masking_input = Some(MaskInputArg::MagnitudeFirst);
+            args.pipeline.qsm_algorithm = Some(QsmAlgorithmArg::Tkd);
+            args.pipeline.unwrapping_algorithm = Some(UnwrapAlgorithmArg::Laplacian);
+            args.pipeline.bf_algorithm = Some(BfAlgorithmArg::Vsharp);
+            args.pipeline.masking_input = Some(MaskInputArg::MagnitudeFirst);
             args.dry = false;
             args.no_mem_limit = true;
             args
@@ -725,13 +727,13 @@ mod integration_tests {
 
         let make_args = |do_t2star: bool| {
             let mut args = default_run_args(bids.clone(), out.clone());
-            args.qsm_algorithm = Some(QsmAlgorithmArg::Tkd);
-            args.unwrapping_algorithm = Some(UnwrapAlgorithmArg::Laplacian);
-            args.bf_algorithm = Some(BfAlgorithmArg::Vsharp);
-            args.masking_input = Some(MaskInputArg::Magnitude);
+            args.pipeline.qsm_algorithm = Some(QsmAlgorithmArg::Tkd);
+            args.pipeline.unwrapping_algorithm = Some(UnwrapAlgorithmArg::Laplacian);
+            args.pipeline.bf_algorithm = Some(BfAlgorithmArg::Vsharp);
+            args.pipeline.masking_input = Some(MaskInputArg::Magnitude);
             args.dry = false;
             args.no_mem_limit = true;
-            args.do_t2starmap = do_t2star;
+            args.pipeline.do_t2starmap = do_t2star;
             args
         };
 
@@ -762,16 +764,16 @@ mod integration_tests {
         testutils::create_multi_echo_bids(&bids);
 
         let mut args = default_run_args(bids, out.clone());
-        args.qsm_algorithm = Some(QsmAlgorithmArg::Tkd);
-        args.unwrapping_algorithm = Some(UnwrapAlgorithmArg::Laplacian);
-        args.bf_algorithm = Some(BfAlgorithmArg::Vsharp);
-        args.masking_input = Some(MaskInputArg::Magnitude);
-        args.phase_offset_removal = Some(true);
+        args.pipeline.qsm_algorithm = Some(QsmAlgorithmArg::Tkd);
+        args.pipeline.unwrapping_algorithm = Some(UnwrapAlgorithmArg::Laplacian);
+        args.pipeline.bf_algorithm = Some(BfAlgorithmArg::Vsharp);
+        args.pipeline.masking_input = Some(MaskInputArg::Magnitude);
+        args.pipeline.phase_offset_removal = Some(true);
         args.dry = false;
         args.no_mem_limit = true;
-        args.do_swi = true;
-        args.do_t2starmap = true;
-        args.do_r2starmap = true;
+        args.pipeline.do_swi = true;
+        args.pipeline.do_t2starmap = true;
+        args.pipeline.do_r2starmap = true;
         super::run::execute(args).unwrap();
 
         let deriv = out.join("derivatives/qsmxt");
@@ -789,14 +791,14 @@ mod integration_tests {
         testutils::create_single_echo_bids(&bids);
 
         let mut args = default_run_args(bids, out.clone());
-        args.qsm_algorithm = Some(QsmAlgorithmArg::Tgv);
-        args.masking_input = Some(MaskInputArg::MagnitudeFirst);
-        args.tgv_params.tgv_iterations = Some(5);
-        args.tgv_params.tgv_erosions = Some(0);
+        args.pipeline.qsm_algorithm = Some(QsmAlgorithmArg::Tgv);
+        args.pipeline.masking_input = Some(MaskInputArg::MagnitudeFirst);
+        args.pipeline.tgv_params.tgv_iterations = Some(5);
+        args.pipeline.tgv_params.tgv_erosions = Some(0);
         args.dry = false;
         args.no_mem_limit = true;
-        args.inhomogeneity_correction = true;
-        args.mask_sections_cli = Some(vec!["phase-quality,threshold:otsu".to_string()]);
+        args.pipeline.inhomogeneity_correction = true;
+        args.pipeline.mask_sections_cli = Some(vec!["phase-quality,threshold:otsu".to_string()]);
         super::run::execute(args).unwrap();
 
         assert!(out.join("derivatives/qsmxt/sub-1/anat/sub-1_Chimap.nii").exists());
@@ -810,13 +812,13 @@ mod integration_tests {
         testutils::create_single_echo_bids(&bids);
 
         let mut args = default_run_args(bids, out.clone());
-        args.qsm_algorithm = Some(QsmAlgorithmArg::Tkd);
-        args.unwrapping_algorithm = Some(UnwrapAlgorithmArg::Laplacian);
-        args.bf_algorithm = Some(BfAlgorithmArg::Vsharp);
+        args.pipeline.qsm_algorithm = Some(QsmAlgorithmArg::Tkd);
+        args.pipeline.unwrapping_algorithm = Some(UnwrapAlgorithmArg::Laplacian);
+        args.pipeline.bf_algorithm = Some(BfAlgorithmArg::Vsharp);
         args.dry = false;
         args.no_mem_limit = true;
         args.clean_intermediates = true;
-        args.mask_sections_cli = Some(vec!["phase-quality,threshold:otsu,dilate:1,erode:1".to_string()]);
+        args.pipeline.mask_sections_cli = Some(vec!["phase-quality,threshold:otsu,dilate:1,erode:1".to_string()]);
         super::run::execute(args).unwrap();
 
         assert!(out.join("derivatives/qsmxt/sub-1/anat/sub-1_Chimap.nii").exists());
@@ -992,9 +994,46 @@ mod integration_tests {
             time: "01:00:00".to_string(),
             mem: 16, cpus_per_task: 2, submit: false,
             include: None, exclude: None, num_echoes: None,
+            pipeline: Default::default(),
         }).unwrap();
 
         assert!(out.join("derivatives/qsmxt/slurm").exists());
+    }
+
+    /// The jobs run `qsmxt run --config <pipeline_config.toml>`, so the written
+    /// config must carry the requested pipeline — not the defaults.
+    #[test]
+    fn test_slurm_writes_requested_pipeline_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let bids = dir.path().join("bids");
+        let out = dir.path().join("out");
+        testutils::create_single_echo_bids(&bids);
+
+        super::slurm::execute(SlurmArgs {
+            bids_dir: bids,
+            output_dir: Some(out.clone()),
+            account: "testacct".to_string(),
+            partition: None,
+            config: None,
+            time: "01:00:00".to_string(),
+            mem: 16, cpus_per_task: 2, submit: false,
+            include: None, exclude: None, num_echoes: None,
+            pipeline: PipelineArgs {
+                qsm_algorithm: Some(QsmAlgorithmArg::Tkd),
+                unwrapping_algorithm: Some(UnwrapAlgorithmArg::Laplacian),
+                bf_algorithm: Some(BfAlgorithmArg::Pdf),
+                ..Default::default()
+            },
+        }).unwrap();
+
+        let written = std::fs::read_to_string(out.join("derivatives/qsmxt/pipeline_config.toml")).unwrap();
+        let config: crate::pipeline::config::PipelineConfig = toml::from_str(&written).unwrap();
+        assert_eq!(config.inversion.algorithm, crate::pipeline::config::QsmAlgorithm::Tkd);
+        assert_eq!(
+            config.field_mapping.unwrapping_algorithm,
+            crate::pipeline::config::UnwrappingAlgorithm::Laplacian
+        );
+        assert_eq!(config.bg_removal.algorithm, crate::pipeline::config::BfAlgorithm::Pdf);
     }
 
     #[test]

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -18,7 +18,7 @@ pub fn execute(args: RunArgs) -> crate::Result<()> {
         PipelineConfig::default()
     };
 
-    crate::pipeline::config::apply_run_overrides(&mut config, &args);
+    crate::pipeline::config::apply_run_overrides(&mut config, &args.pipeline);
     
 
     // Discover BIDS runs

--- a/src/commands/slurm.rs
+++ b/src/commands/slurm.rs
@@ -3,11 +3,16 @@ use crate::cli::SlurmArgs;
 use crate::pipeline::config::PipelineConfig;
 
 pub fn execute(args: SlurmArgs) -> crate::Result<()> {
-    let config = if let Some(ref path) = args.config {
+    // Build config the same way `qsmxt run` does: file -> CLI/TUI overrides.
+    // Without the overrides the generated jobs silently fall back to the
+    // pipeline defaults instead of the requested settings.
+    let mut config = if let Some(ref path) = args.config {
         crate::pipeline::config::load_config(path)?
     } else {
         PipelineConfig::default()
     };
+
+    crate::pipeline::config::apply_run_overrides(&mut config, &args.pipeline);
 
     let filter = DiscoveryFilter {
         include: args.include.clone(),

--- a/src/executor/slurm.rs
+++ b/src/executor/slurm.rs
@@ -18,7 +18,7 @@ pub fn generate_all_slurm(
     runs: &[QsmRun],
     bids_dir: &Path,
     output_dir: &Path,
-    _config: &PipelineConfig,
+    config: &PipelineConfig,
     account: &str,
     partition: Option<&str>,
     time: &str,
@@ -31,7 +31,7 @@ pub fn generate_all_slurm(
 
     // Save config for SLURM jobs to reference
     let config_path = derivatives_dir.join("pipeline_config.toml");
-    std::fs::write(&config_path, _config.to_toml().unwrap_or_default())?;
+    std::fs::write(&config_path, config.to_toml().unwrap_or_default())?;
 
     let qsmxt_bin = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("qsmxt"));
 

--- a/src/pipeline/config.rs
+++ b/src/pipeline/config.rs
@@ -84,7 +84,10 @@ pub fn apply_qsmart_overrides(config: &mut PipelineConfig, p: &cli::QsmartParamA
 }
 
 /// Maps flat CLI flags to nested config fields.
-pub fn apply_run_overrides(config: &mut PipelineConfig, args: &cli::RunArgs) {
+///
+/// Shared by `qsmxt run` and `qsmxt slurm` (both flatten `PipelineArgs`), so a
+/// pipeline configured once resolves identically in either execution mode.
+pub fn apply_run_overrides(config: &mut PipelineConfig, args: &cli::PipelineArgs) {
         // ── Inversion algorithm ──
         if let Some(a) = args.qsm_algorithm {
             config.inversion.algorithm = qsm_algorithm_arg_to_config(a);
@@ -501,7 +504,7 @@ mod tests {
             _ => panic!("expected Run subcommand"),
         };
         let mut rebuilt = PipelineConfig::default();
-        apply_run_overrides(&mut rebuilt, &run_args);
+        apply_run_overrides(&mut rebuilt, &run_args.pipeline);
 
         assert_eq!(rebuilt.inversion.algorithm, QsmAlgorithm::Qsmart);
         assert_eq!(rebuilt.inversion.qsmart.inversion, QsmAlgorithm::Tv);
@@ -520,7 +523,7 @@ mod tests {
             _ => panic!("expected Run subcommand"),
         };
         let mut config = PipelineConfig::default();
-        apply_run_overrides(&mut config, &run_args);
+        apply_run_overrides(&mut config, &run_args.pipeline);
         config
     }
 

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -100,12 +100,39 @@ fn push_if_changed(parts: &mut Vec<String>, flag: &str, current: &str, default: 
 
 pub fn build_run_args(app: &App) -> crate::Result<RunArgs> {
     let form = &app.form;
-    let ps = &app.pipeline_state;
     if form.bids_dir.is_empty() {
         return Err(crate::error::QsmxtError::Config(
             "BIDS directory is required".to_string(),
         ));
     }
+
+    Ok(RunArgs {
+        bids_dir: expand_tilde(&form.bids_dir),
+        output_dir: if form.output_dir.is_empty() { None } else { Some(expand_tilde(&form.output_dir)) },
+        config: parse_optional_path(&form.config_file),
+        include: app.filter_state.get_include_exclude().0,
+        exclude: app.filter_state.get_include_exclude().1,
+        num_echoes: parse_optional_usize(&app.filter_state.num_echoes),
+        n_procs: parse_optional_usize(&form.n_procs),
+        source_dicom: None,
+        dicom_outputs: None,
+        dry: form.dry_run,
+        debug: form.debug,
+        mem_limit_gb: None,
+        no_mem_limit: false,
+        force: false,
+        clean_intermediates: false,
+        pipeline: pipeline_args_from_app(app),
+    })
+}
+
+/// Pipeline settings as they stand in the TUI form.
+///
+/// Shared by the local (`RunArgs`) and SLURM (`SlurmArgs`) paths so both
+/// execute the pipeline the user configured, not the defaults.
+pub fn pipeline_args_from_app(app: &App) -> PipelineArgs {
+    let form = &app.form;
+    let ps = &app.pipeline_state;
 
     let qsm_options = [
         QsmAlgorithmArg::Rts,
@@ -161,13 +188,8 @@ pub fn build_run_args(app: &App) -> crate::Result<RunArgs> {
         SeparationAlgorithmArg::SusepNet,
         SeparationAlgorithmArg::ChiSepNet,
     ];
-    Ok(RunArgs {
-        bids_dir: expand_tilde(&form.bids_dir),
-        output_dir: if form.output_dir.is_empty() { None } else { Some(expand_tilde(&form.output_dir)) },
-        config: parse_optional_path(&form.config_file),
-        include: app.filter_state.get_include_exclude().0,
-        exclude: app.filter_state.get_include_exclude().1,
-        num_echoes: parse_optional_usize(&app.filter_state.num_echoes),
+
+    PipelineArgs {
         qsm_algorithm: Some(qsm_options[ps.qsm_algorithm]),
         unwrapping_algorithm: Some(unwrap_options[ps.unwrapping_algorithm]),
         bf_algorithm: Some(bf_options[ps.bf_algorithm]),
@@ -455,7 +477,6 @@ pub fn build_run_args(app: &App) -> crate::Result<RunArgs> {
             tile_size: parse_optional_usize(&ps.dl_tile_size),
             tile_halo: parse_optional_usize(&ps.dl_tile_halo),
         },
-        n_procs: parse_optional_usize(&form.n_procs),
         homogeneity_sigma_mm: None,
         homogeneity_nbox: None,
         linear_fit_reliability_threshold: None,
@@ -472,8 +493,6 @@ pub fn build_run_args(app: &App) -> crate::Result<RunArgs> {
         use_custom_r2: if ps.custom_r2_tool.trim().is_empty() { None } else { Some(ps.custom_r2_tool.trim().to_string()) },
         use_custom_r2prime: if ps.custom_r2prime_tool.trim().is_empty() { None } else { Some(ps.custom_r2prime_tool.trim().to_string()) },
         export_dicom: form.export_dicom,
-        source_dicom: None,
-        dicom_outputs: None,
         inhomogeneity_correction: ps.inhomogeneity_correction,
         no_inhomogeneity_correction: !ps.inhomogeneity_correction,
         obliquity_threshold: parse_optional_f64(&ps.obliquity_threshold),
@@ -489,13 +508,7 @@ pub fn build_run_args(app: &App) -> crate::Result<RunArgs> {
             }).collect();
             if secs.is_empty() { None } else { Some(secs) }
         },
-        dry: form.dry_run,
-        debug: form.debug,
-        mem_limit_gb: None,
-        no_mem_limit: false,
-        force: false,
-        clean_intermediates: false,
-    })
+    }
 }
 
 pub(super) fn expand_tilde(s: &str) -> PathBuf {
@@ -574,6 +587,7 @@ pub fn build_slurm_args(app: &App) -> crate::Result<SlurmArgs> {
         include,
         exclude,
         num_echoes: parse_optional_usize(&app.filter_state.num_echoes),
+        pipeline: pipeline_args_from_app(app),
     })
 }
 
@@ -1004,7 +1018,7 @@ mod tests {
         let args = build_run_args(&app).unwrap();
         assert_eq!(args.bids_dir, PathBuf::from("/bids"));
         assert_eq!(args.output_dir, Some(PathBuf::from("/out")));
-        assert_eq!(args.qsm_algorithm, Some(crate::cli::QsmAlgorithmArg::Rts));
+        assert_eq!(args.pipeline.qsm_algorithm, Some(crate::cli::QsmAlgorithmArg::Rts));
     }
 
     #[test]
@@ -1032,9 +1046,9 @@ mod tests {
         app.pipeline_state.tkd_threshold = "0.15".to_string();
         app.form.n_procs = "8".to_string();
         let args = build_run_args(&app).unwrap();
-        assert_eq!(args.bet_fractional_intensity, Some(0.3));
-        assert_eq!(args.rts_params.rts_delta, Some(0.2));
-        assert_eq!(args.tgv_params.tgv_iterations, Some(500));
+        assert_eq!(args.pipeline.bet_fractional_intensity, Some(0.3));
+        assert_eq!(args.pipeline.rts_params.rts_delta, Some(0.2));
+        assert_eq!(args.pipeline.tgv_params.tgv_iterations, Some(500));
         assert_eq!(args.n_procs, Some(8));
     }
 
@@ -1050,13 +1064,13 @@ mod tests {
         app.form.dry_run = true;
         app.form.debug = true;
         let args = build_run_args(&app).unwrap();
-        assert!(args.do_swi);
-        assert!(args.do_t2starmap);
-        assert!(args.do_r2starmap);
-        assert!(args.inhomogeneity_correction);
+        assert!(args.pipeline.do_swi);
+        assert!(args.pipeline.do_t2starmap);
+        assert!(args.pipeline.do_r2starmap);
+        assert!(args.pipeline.inhomogeneity_correction);
         assert!(args.dry);
         assert!(args.debug);
-        assert_eq!(args.phase_offset_removal, Some(true)); // default mcpc3ds
+        assert_eq!(args.pipeline.phase_offset_removal, Some(true)); // default mcpc3ds
     }
 
     #[test]
@@ -1066,7 +1080,7 @@ mod tests {
         app.form.output_dir = "/o".to_string();
         app.pipeline_state.phase_offset_removal = false;
         let args = build_run_args(&app).unwrap();
-        assert_eq!(args.phase_offset_removal, Some(false));
+        assert_eq!(args.pipeline.phase_offset_removal, Some(false));
     }
 
 
@@ -1089,7 +1103,7 @@ mod tests {
         app.form.output_dir = "/o".to_string();
         app.pipeline_state.obliquity_threshold = "5.0".to_string();
         let args = build_run_args(&app).unwrap();
-        assert_eq!(args.obliquity_threshold, Some(5.0));
+        assert_eq!(args.pipeline.obliquity_threshold, Some(5.0));
     }
 
     // --- parse helpers ---
@@ -1276,6 +1290,76 @@ mod tests {
         assert_eq!(args.cpus_per_task, 8);
         assert!(args.submit);
         assert_eq!(args.config, Some(PathBuf::from("config.toml")));
+    }
+
+    /// The command the TUI prints in SLURM mode carries the pipeline flags, so
+    /// `qsmxt slurm` must actually accept them — a copy-pasted command has to run.
+    #[test]
+    fn test_slurm_command_string_parses() {
+        use clap::Parser;
+        let mut app = default_app();
+        app.form.bids_dir = "/bids".to_string();
+        app.form.execution_mode = 1;
+        app.form.slurm_account = "acct".to_string();
+        app.pipeline_state.qsm_algorithm = 4; // tgv
+        app.pipeline_state.bet_fractional_intensity = "0.3".to_string();
+
+        let cmd = build_command_string(&app);
+        let argv: Vec<String> = cmd.split_whitespace().map(|s| s.to_string()).collect();
+        let cli = crate::cli::Cli::try_parse_from(&argv)
+            .unwrap_or_else(|e| panic!("TUI SLURM command did not parse: {}\ncmd: {}", e, cmd));
+        match cli.command {
+            crate::cli::Command::Slurm(args) => {
+                assert_eq!(args.pipeline.qsm_algorithm, Some(crate::cli::QsmAlgorithmArg::Tgv));
+                assert_eq!(args.pipeline.bet_fractional_intensity, Some(0.3));
+                assert_eq!(args.account, "acct");
+            }
+            _ => panic!("expected the slurm subcommand"),
+        }
+    }
+
+    /// Regression: SLURM mode used to drop every pipeline setting, so the
+    /// generated jobs ran the defaults (romeo/threshold/sharp/rts) instead of
+    /// the configured pipeline. The SLURM args must carry the same pipeline
+    /// settings as the local args.
+    #[test]
+    fn test_build_slurm_args_carries_pipeline_settings() {
+        let mut app = default_app();
+        app.form.bids_dir = "/bids".to_string();
+        app.form.slurm_account = "acct".to_string();
+        app.pipeline_state.qsm_algorithm = 4; // tgv
+        app.pipeline_state.unwrapping_algorithm = 1; // laplacian
+        app.pipeline_state.bf_algorithm = 1; // pdf
+        app.pipeline_state.bet_fractional_intensity = "0.3".to_string();
+        app.form.do_swi = true;
+
+        let slurm = build_slurm_args(&app).unwrap();
+        assert_eq!(slurm.pipeline.qsm_algorithm, Some(crate::cli::QsmAlgorithmArg::Tgv));
+        assert_eq!(slurm.pipeline.unwrapping_algorithm, Some(crate::cli::UnwrapAlgorithmArg::Laplacian));
+        assert_eq!(slurm.pipeline.bf_algorithm, Some(crate::cli::BfAlgorithmArg::Pdf));
+        assert_eq!(slurm.pipeline.bet_fractional_intensity, Some(0.3));
+        assert!(slurm.pipeline.do_swi);
+    }
+
+    /// The pipeline the SLURM jobs get must be the one a local run would use.
+    #[test]
+    fn test_slurm_and_local_resolve_to_the_same_config() {
+        let mut app = default_app();
+        app.form.bids_dir = "/bids".to_string();
+        app.form.slurm_account = "acct".to_string();
+        app.pipeline_state.qsm_algorithm = 4; // tgv
+        app.pipeline_state.unwrapping_algorithm = 1; // laplacian
+        app.pipeline_state.bf_algorithm = 1; // pdf
+        app.pipeline_state.bipolar_correction = true;
+
+        let mut local = PipelineConfig::default();
+        crate::pipeline::config::apply_run_overrides(&mut local, &build_run_args(&app).unwrap().pipeline);
+        let mut slurm = PipelineConfig::default();
+        crate::pipeline::config::apply_run_overrides(&mut slurm, &build_slurm_args(&app).unwrap().pipeline);
+
+        assert_eq!(slurm.to_toml().unwrap(), local.to_toml().unwrap());
+        // ... and it is not merely the default pipeline.
+        assert_ne!(slurm.to_toml().unwrap(), PipelineConfig::default().to_toml().unwrap());
     }
 
     // --- output_dir optional ---

--- a/tests/run_args_coverage.rs
+++ b/tests/run_args_coverage.rs
@@ -1,14 +1,28 @@
-//! RunArgs-coverage guard.
+//! RunArgs/PipelineArgs-coverage guard.
 //!
 //! Sibling of qsmxt-config's tests/param_coverage.rs, one layer up: every
 //! `qsmxt run` CLI flag must actually be consumed by the run pipeline. v9
 //! shipped --masking-algorithm and --masking-input parsed but silently
-//! ignored; this test goes red if a RunArgs field exists that neither
-//! apply_run_overrides() nor run::execute() reads.
+//! ignored; this test goes red if a RunArgs or PipelineArgs field exists that
+//! neither apply_run_overrides() nor run::execute() reads.
 //!
 //! The check is textual (the binary crate has no lib target to introspect):
 //! a field `foo` counts as consumed if `args.foo` appears in the consumer
 //! sources. Fields read via destructuring would need this test updated.
+
+fn struct_fields(cli_src: &str, name: &str) -> Vec<String> {
+    let start = cli_src
+        .find(&format!("pub struct {} {{", name))
+        .unwrap_or_else(|| panic!("{} struct not found", name));
+    let body = &cli_src[start..];
+    let end = body.find("\n}").unwrap_or_else(|| panic!("{} struct end not found", name));
+    body[..end]
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("pub "))
+        .filter_map(|rest| rest.split_once(':'))
+        .map(|(name, _)| name.trim().to_string())
+        .collect()
+}
 
 #[test]
 fn every_run_arg_is_consumed() {
@@ -18,26 +32,37 @@ fn every_run_arg_is_consumed() {
         include_str!("../src/commands/run.rs"),
     );
 
-    let start = cli_src.find("pub struct RunArgs {").expect("RunArgs struct not found");
-    let body = &cli_src[start..];
-    let end = body.find("\n}").expect("RunArgs struct end not found");
-    let body = &body[..end];
+    let mut fields = struct_fields(cli_src, "RunArgs");
+    fields.extend(struct_fields(cli_src, "PipelineArgs"));
 
-    let mut missing = Vec::new();
-    for line in body.lines() {
-        let line = line.trim();
-        if let Some(rest) = line.strip_prefix("pub ") {
-            if let Some((name, _)) = rest.split_once(':') {
-                let name = name.trim();
-                if !consumers.contains(&format!("args.{}", name)) {
-                    missing.push(name.to_string());
-                }
-            }
-        }
-    }
+    let missing: Vec<_> = fields
+        .into_iter()
+        .filter(|name| !consumers.contains(&format!("args.{}", name)))
+        .collect();
     assert!(
         missing.is_empty(),
-        "RunArgs field(s) {missing:?} are parsed but never applied — wire them \
+        "RunArgs/PipelineArgs field(s) {missing:?} are parsed but never applied — wire them \
          into apply_run_overrides() or run::execute(), or remove the flag(s)"
+    );
+}
+
+/// The SLURM path must apply the same pipeline overrides as the local path —
+/// otherwise generated jobs silently run the defaults (issue: TUI SLURM mode
+/// wrote a default pipeline_config.toml regardless of the chosen settings).
+#[test]
+fn slurm_flattens_and_applies_pipeline_args() {
+    let cli_src = include_str!("../src/cli.rs");
+    let slurm_start = cli_src.find("pub struct SlurmArgs {").expect("SlurmArgs not found");
+    let slurm_body = &cli_src[slurm_start..];
+    let slurm_body = &slurm_body[..slurm_body.find("\n}").expect("SlurmArgs end not found")];
+    assert!(
+        slurm_body.contains("pub pipeline: PipelineArgs"),
+        "SlurmArgs must flatten PipelineArgs so `qsmxt slurm` takes the same pipeline flags as `qsmxt run`"
+    );
+
+    let slurm_cmd = include_str!("../src/commands/slurm.rs");
+    assert!(
+        slurm_cmd.contains("apply_run_overrides(&mut config, &args.pipeline)"),
+        "slurm::execute() must apply the pipeline overrides before generating job scripts"
     );
 }


### PR DESCRIPTION
Reported by a user: with the TUI's `slurm` execution option, the generated `pipeline_config.toml` was written from the QSMxT defaults (romeo, threshold masking, sharp, rts) rather than the options selected in the pipeline settings, so the submitted jobs ran with the default parameters. Their workaround was to generate the config with `Local` and point the SLURM scripts at it.

## Cause

`SlurmArgs` carried only the scheduler settings and the run filters — it had no pipeline fields at all. So `slurm::execute()` did:

```rust
let config = if let Some(path) = args.config { load_config(path)? } else { PipelineConfig::default() };
```

and passed that straight to the script generator, which writes `derivatives/qsmxt/pipeline_config.toml` and points every job at it via `qsmxt run --config …`. With no `--config` file supplied, that is the default pipeline. The local path was unaffected because it goes through `RunArgs` + `apply_run_overrides()`, which map every TUI setting onto the config.

Two related consequences of the same gap:

* `qsmxt slurm` on the command line accepted no pipeline options either.
* The command string the TUI prints in SLURM mode *did* include those flags, so a copy-pasted command failed to parse.

## Changes

* `src/cli.rs` — the pipeline-config flags move out of `RunArgs` into a new `PipelineArgs`, flattened into **both** `RunArgs` and `SlurmArgs`. Run-only flags (`--n-procs`, `--dry`, `--debug`, `--force`, `--mem-limit-gb`, `--source-dicom`, …) stay on `run`.
* `src/commands/slurm.rs` — applies `apply_run_overrides()` to the config before generating scripts, exactly as `run::execute()` does.
* `src/tui/command.rs` — the form → args conversion is extracted into `pipeline_args_from_app()` and used by both the local and SLURM paths, so the two cannot drift apart again.
* `src/pipeline/config.rs`, `src/commands/run.rs` — `apply_run_overrides()` now takes `&PipelineArgs`; body unchanged.
* Docs — the HPC section notes that `qsmxt slurm` takes the same pipeline options as `qsmxt run`.

This is an additive CLI change: existing `qsmxt run` and `qsmxt slurm` invocations keep working, and `qsmxt slurm --help` now lists the pipeline options.

## Tests

* `tui::command`: SLURM and local args resolve to a byte-identical config TOML, and the SLURM args carry the selected algorithms/parameters.
* `tui::command`: the command string printed in SLURM mode parses back through clap as a `slurm` invocation with the expected pipeline flags.
* `commands::integration_tests`: end-to-end — the `pipeline_config.toml` written by `qsmxt slurm` carries the requested tkd/laplacian/pdf rather than the defaults.
* `tests/run_args_coverage.rs`: the "every flag is consumed" guard now covers `PipelineArgs`, plus a check that `SlurmArgs` flattens it and that `slurm::execute` applies the overrides.

`cargo test` — 561 passed, 0 failed (+2 in `run_args_coverage`). `cargo clippy --all-targets` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbKEWf8icw6UvDBJAiy8NB

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbKEWf8icw6UvDBJAiy8NB)_