### PR TITLE
feat(masking): HD-BET deep-learning brain extraction + signal-gated erosion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,18 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,12 +98,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "anymap2"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
-
-[[package]]
 name = "anymap3"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,7 +150,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "log",
- "nom 8.0.0",
+ "nom",
  "num-rational",
  "v_frame",
 ]
@@ -190,18 +172,22 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "56d87354e4229f54a44f7bf2435906a4656dba36026ab6eaca629a2c436a691c"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5727b15fa97d4f4fee0a3b7c3d550ed0269f54329207b86388de918604e31269"
+dependencies = [
+ "borsh",
+ "serde",
+]
 
 [[package]]
 name = "bit_field"
@@ -234,6 +220,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "borsh"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "553c5d846a6ba5150c65e3b1b8ec073bcf1abc20f9b7220de384a4443ea4e20a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cdfe656708a01f89b451a7d36466e6fe6c414de0aa18fc54f864f6f9ca9f56"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -323,6 +333,23 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -447,6 +474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,20 +601,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-
-[[package]]
 name = "derive-new"
-version = "0.5.9"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -776,16 +806,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "doc-comment"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
-
-[[package]]
 name = "downcast-rs"
-version = "1.2.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "dyn-clone"
@@ -794,10 +818,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "dyn-hash"
-version = "0.2.2"
+name = "dyn-eq"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15401da73a9ed8c80e3b2d4dc05fe10e7b72d7243b9f614e516a44fa99986e88"
+checksum = "5c2d035d21af5cde1a6f5c7b444a5bf963520a9f142e5d06931178433d7d5388"
+
+[[package]]
+name = "dyn-hash"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fdab65db9274e0168143841eb8f864a0a21f8b1b8d2ba6812bbe6024346e99e"
 
 [[package]]
 name = "either"
@@ -925,6 +955,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,10 +1032,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-ord"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1071,6 +1124,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1095,22 +1149,26 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1433,6 +1491,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,16 +1739,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
-name = "kstring"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
-dependencies = [
- "serde",
- "static_assertions",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,63 +1789,6 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "liquid"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9338405fdbc0bce9b01695b2a2ef6b20eca5363f385d47bce48ddf8323cc25"
-dependencies = [
- "doc-comment",
- "liquid-core",
- "liquid-derive",
- "liquid-lib",
- "serde",
-]
-
-[[package]]
-name = "liquid-core"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb8fed70857010ed9016ed2ce5a7f34e7cc51d5d7255c9c9dc2e3243e490b42"
-dependencies = [
- "anymap2",
- "itertools 0.13.0",
- "kstring",
- "liquid-derive",
- "num-traits",
- "pest",
- "pest_derive",
- "regex",
- "serde",
- "time",
-]
-
-[[package]]
-name = "liquid-derive"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b51f1d220e3fa869e24cfd75915efe3164bd09bb11b3165db3f37f57bf673e3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "liquid-lib"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1794b5605e9f8864a8a4f41aa97976b42512cc81093f8c885d29fb94c6c556"
-dependencies = [
- "itertools 0.13.0",
- "liquid-core",
- "once_cell",
- "percent-encoding",
- "regex",
- "time",
- "unicode-segmentation",
-]
 
 [[package]]
 name = "litemap"
@@ -1871,10 +1871,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
+name = "memo-map"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+checksum = "5449c8c750f1a07ea702bbd212bd999fceece9b3d1508b17023b3e174583124b"
+
+[[package]]
+name = "minijinja"
+version = "2.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86886cf6dbf4e614b19c9a1eec9775f021869d7eadde0fc73921a81b90c9b4c9"
+dependencies = [
+ "memo-map",
+ "serde",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1915,6 +1925,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,7 +1956,7 @@ dependencies = [
  "byteordered",
  "either",
  "flate2",
- "ndarray",
+ "ndarray 0.16.1",
  "num-complex",
  "num-derive",
  "num-traits",
@@ -1941,21 +1966,20 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
-name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nom-language"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1983,12 +2007,6 @@ dependencies = [
  "bytemuck",
  "num-traits",
 ]
-
-[[package]]
-name = "num-conv"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2089,52 +2107,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -2186,12 +2168,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,6 +2193,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
 dependencies = [
  "num-integer",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.15+spec-1.1.0",
 ]
 
 [[package]]
@@ -2249,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2259,26 +2244,26 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "qsm-core"
 version = "0.0.0"
-source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.30.0#dd685ab07b73cec7160eef010a11253e1f4e35cb"
+source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.31.0#7798f90a870e11c808a2cd540b2115b912d2275b"
 dependencies = [
  "bytemuck",
  "delaunator",
  "flate2",
- "ndarray",
+ "ndarray 0.16.1",
  "nifti",
  "num-complex",
  "num-traits",
@@ -2286,6 +2271,7 @@ dependencies = [
  "rustfft",
  "serde",
  "sha2",
+ "tract-linalg",
  "tract-onnx",
  "ureq",
 ]
@@ -2362,7 +2348,18 @@ checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2372,7 +2369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2385,13 +2382,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_distr"
-version = "0.4.3"
+name = "rand_core"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -2441,7 +2444,7 @@ dependencies = [
  "once_cell",
  "paste",
  "profiling",
- "rand",
+ "rand 0.8.6",
  "rand_chacha",
  "simd_helpers",
  "system-deps",
@@ -2652,6 +2655,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
 
 [[package]]
+name = "safetensors"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b079b829cb27a1c3c374341345ed2e8b2c0c839034522cee576c140bd7f846"
+dependencies = [
+ "hashbrown 0.16.1",
+ "libc",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,7 +2757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2850,12 +2866,11 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string-interner"
-version = "0.15.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f9fdfdd31a0ff38b59deb401be81b73913d76c9cc5b1aed4e1330a223420b9"
+checksum = "ad3df9b59e2eded8d825c7c4363ad339a20fb6bc0b9a4778560f518f59910b15"
 dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "serde",
 ]
 
@@ -2910,17 +2925,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
 dependencies = [
  "is_ci",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]
@@ -3061,36 +3065,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
-dependencies = [
- "deranged",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
-
-[[package]]
-name = "time-macros"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3101,21 +3075,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3123,8 +3082,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3137,6 +3096,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3145,9 +3113,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.15+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1340ea94a5856333492c9064b02c778b191dd2c853778d9609debdcdfea3a614"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3189,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "tract-core"
-version = "0.21.10"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b5347639690871b124593a8c8903f1f369531498b8abaebd18eb5c58163971"
+checksum = "67786dad63505354ec2d1b3925c78fdd155d8101558f3810639aa55077156d81"
 dependencies = [
  "anyhow",
  "anymap3",
@@ -3199,15 +3188,19 @@ dependencies = [
  "derive-new",
  "downcast-rs",
  "dyn-clone",
+ "dyn-eq",
+ "erased-serde",
+ "inventory",
  "lazy_static",
  "log",
  "maplit",
- "ndarray",
+ "ndarray 0.17.2",
  "num-complex",
  "num-integer",
  "num-traits",
- "paste",
+ "pastey",
  "rustfft",
+ "serde",
  "smallvec",
  "tract-data",
  "tract-linalg",
@@ -3215,20 +3208,24 @@ dependencies = [
 
 [[package]]
 name = "tract-data"
-version = "0.21.10"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a3f476a1804e05708e9bc5e2d29dcab82bad531e357d3d14d7da80fbba0b6d"
+checksum = "bfbe59c58d1c7c52941c73e7efe08059fbb1cab29510f9bc459b95e0ab32d459"
 dependencies = [
  "anyhow",
  "downcast-rs",
  "dyn-clone",
+ "dyn-eq",
  "dyn-hash",
  "half",
- "itertools 0.12.1",
+ "inventory",
+ "itertools 0.15.0",
  "lazy_static",
+ "libm",
  "maplit",
- "ndarray",
- "nom 7.1.3",
+ "ndarray 0.17.2",
+ "nom",
+ "nom-language",
  "num-integer",
  "num-traits",
  "parking_lot",
@@ -3238,10 +3235,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tract-hir"
-version = "0.21.10"
+name = "tract-extra"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dca047ba1151fe3446fb0194d4b6ddb9ae8f361337c47a267870c53605fbafb"
+checksum = "6ec73a353523e22c79f1e23a38af32091326dd11789bcf11ad79624872dc1566"
+dependencies = [
+ "tract-nnef",
+ "tract-pulse",
+]
+
+[[package]]
+name = "tract-hir"
+version = "0.23.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "981e9a8d15d54201afc91ea7b06786b6ec52cb5627ce2a8403c1ee3a2c1f96b2"
 dependencies = [
  "derive-new",
  "log",
@@ -3250,43 +3257,48 @@ dependencies = [
 
 [[package]]
 name = "tract-linalg"
-version = "0.21.10"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8e0703eb53ef1bbf77050ff261675818dd5f0d6c27044c6e48ede9b845f9e0"
+checksum = "eab0651b49eaa0c64bebe290cf981878f47843cf1bb424c15bdef832f8d1e153"
 dependencies = [
  "byteorder",
  "cc",
  "derive-new",
  "downcast-rs",
  "dyn-clone",
+ "dyn-eq",
  "dyn-hash",
  "half",
+ "inventory",
  "lazy_static",
- "liquid",
- "liquid-core",
- "liquid-derive",
+ "libc",
  "log",
+ "minijinja",
  "num-traits",
- "paste",
+ "pastey",
  "rayon",
  "scan_fmt",
- "smallvec",
- "time",
  "tract-data",
- "unicode-normalization",
  "walkdir",
 ]
 
 [[package]]
 name = "tract-nnef"
-version = "0.21.10"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cb88a4367ec2c695610223cf886f01fc1deb5c9a82c7a74b1a5d32dc0b1466"
+checksum = "051be16c8824ceefdb9cd0c121d7a97c89ca530c6cb0d1f1af6fcc27d8531597"
 dependencies = [
  "byteorder",
+ "erased-serde",
  "flate2",
  "log",
- "nom 7.1.3",
+ "minijinja",
+ "nom",
+ "nom-language",
+ "safetensors",
+ "serde",
+ "serde_json",
+ "simd-adler32",
  "tar",
  "tract-core",
  "walkdir",
@@ -3294,33 +3306,81 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx"
-version = "0.21.10"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5830aa672b2aa4dc98a97a36e5988eaf77b3ecee65e2601619588d2ca557008"
+checksum = "22c82a3be1f099fa3fb461273b92b1e33685b7546000ab23f963e4c486ec4991"
 dependencies = [
  "bytes",
  "derive-new",
+ "dyn-eq",
  "log",
  "memmap2",
+ "nom",
+ "nom-language",
  "num-integer",
+ "num-rational",
+ "num-traits",
  "prost",
  "smallvec",
+ "tract-extra",
  "tract-hir",
  "tract-nnef",
  "tract-onnx-opl",
+ "tract-transformers",
 ]
 
 [[package]]
 name = "tract-onnx-opl"
-version = "0.21.10"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121d3d224c806ba3d941f4bb50943ad33b59d1da5ae704d0e4e76d2808221f96"
+checksum = "d28bd5314707cbbbf0eb312470768330d392338ab94c405e72d126ff5817d06c"
 dependencies = [
- "getrandom 0.2.17",
+ "dyn-eq",
+ "getrandom 0.4.2",
  "log",
- "rand",
+ "rand 0.10.2",
  "rand_distr",
  "rustfft",
+ "tract-extra",
+ "tract-nnef",
+]
+
+[[package]]
+name = "tract-pulse"
+version = "0.23.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "103941bf671feb7cb11d81747ab224a584b728a31b8dd931ad02a2381f031bf2"
+dependencies = [
+ "downcast-rs",
+ "dyn-eq",
+ "erased-serde",
+ "lazy_static",
+ "log",
+ "serde",
+ "tract-pulse-opl",
+ "tract-transformers",
+]
+
+[[package]]
+name = "tract-pulse-opl"
+version = "0.23.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef5ca8d1aca1269c43aefade345baff14a5c3a69e86c0a2fea19f11eabb1b5a"
+dependencies = [
+ "downcast-rs",
+ "dyn-eq",
+ "lazy_static",
+ "tract-nnef",
+]
+
+[[package]]
+name = "tract-transformers"
+version = "0.23.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467fb40ac38951bfa57202eeaa88028705b2cb1f0ff15d1238fcb6dcb89cf574"
+dependencies = [
+ "float-ord",
+ "rayon",
  "tract-nnef",
 ]
 
@@ -3335,31 +3395,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -3798,6 +3849,15 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = ["dl"]
 dl = ["qsm-core/onnx", "qsm-core/download"]
 
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.30.0", features = ["parallel"] }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.31.0", features = ["parallel"] }
 qsmxt-config = { path = "crates/qsmxt-config" }
 clap = { version = "4", features = ["derive"] }
 const_format = "0.2"

--- a/crates/qsmxt-config/Cargo.toml
+++ b/crates/qsmxt-config/Cargo.toml
@@ -6,7 +6,7 @@ description = "Pipeline configuration, command generation, and methods text for 
 license = "GPL-3.0-only"
 
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.30.0" }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.31.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"

--- a/crates/qsmxt-config/src/bridge.rs
+++ b/crates/qsmxt-config/src/bridge.rs
@@ -416,11 +416,47 @@ fn convert_mask_op(op: &crate::masking::MaskOp) -> PMaskOp {
         crate::masking::MaskOp::Close { radius } => PMaskOp::Close { radius: *radius },
         crate::masking::MaskOp::FillHoles { max_size } => PMaskOp::FillHoles { max_size: *max_size },
         crate::masking::MaskOp::GaussianSmooth { sigma_mm } => PMaskOp::GaussianSmooth { sigma_mm: *sigma_mm },
+        crate::masking::MaskOp::SignalErode { threshold, depth_cap, global_erosions, bias_sigma, min_component } =>
+            PMaskOp::SignalErode(qsm_core::utils::SignalErosionParams {
+                threshold: *threshold,
+                depth_cap: *depth_cap,
+                global_erosions: *global_erosions,
+                bias_sigma: *bias_sigma,
+                min_component: *min_component,
+            }),
+        crate::masking::MaskOp::HdBet { patch, tta } => PMaskOp::HdBet(qsm_core::bet::HdBetParams {
+            patch: (patch[0], patch[1], patch[2]),
+            mirror_tta: *tta,
+            ..Default::default()
+        }),
     }
 }
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn test_convert_new_mask_ops() {
+        use crate::masking::{parse_mask_op, MaskOp};
+        match convert_mask_op(&parse_mask_op("signal-erode:0.7:3:0:10:200").unwrap()) {
+            PMaskOp::SignalErode(p) => assert_eq!(p, qsm_core::utils::SignalErosionParams {
+                threshold: 0.7, depth_cap: 3, global_erosions: 0, bias_sigma: 10.0, min_component: 200,
+            }),
+            other => panic!("wrong op {other:?}"),
+        }
+        match convert_mask_op(&MaskOp::HdBet { patch: [128, 128, 64], tta: true }) {
+            PMaskOp::HdBet(p) => {
+                assert_eq!(p.patch, (128, 128, 64));
+                assert!(p.mirror_tta);
+                assert_eq!(p.tile_step, qsm_core::bet::HdBetParams::default().tile_step);
+            }
+            other => panic!("wrong op {other:?}"),
+        }
+        // Defaults on both sides agree.
+        assert_eq!(convert_mask_op(&MaskOp::hd_bet_default()), PMaskOp::HdBet(Default::default()));
+        assert_eq!(convert_mask_op(&MaskOp::signal_erode_default()), PMaskOp::SignalErode(Default::default()));
+    }
+
     use super::*;
 
     #[test]

--- a/crates/qsmxt-config/src/masking.rs
+++ b/crates/qsmxt-config/src/masking.rs
@@ -40,6 +40,53 @@ pub enum MaskOp {
     Close { radius: usize },
     FillHoles { max_size: usize },
     GaussianSmooth { sigma_mm: f64 },
+    /// Signal-gated erosion (QSM-CI): peel only low-signal boundary voxels (sinus / skull-base
+    /// dropout), after dividing out the receive-coil bias, down to a depth cap. Needs magnitude.
+    SignalErode {
+        #[serde(default = "se_threshold")] threshold: f64,
+        #[serde(default = "se_depth_cap")] depth_cap: usize,
+        #[serde(default = "se_global_erosions")] global_erosions: usize,
+        #[serde(default = "se_bias_sigma")] bias_sigma: f64,
+        #[serde(default = "se_min_component")] min_component: usize,
+    },
+    /// HD-BET deep-learning brain extraction from the magnitude (needs a `dl` build).
+    /// `patch` is the sliding-window size `[x, y, z]` in voxels at 1 mm.
+    HdBet {
+        #[serde(default = "hd_bet_patch")] patch: [usize; 3],
+        #[serde(default)] tta: bool,
+    },
+}
+
+// Defaults come from qsm-core so the two never drift apart.
+fn se_default() -> qsm_core::utils::SignalErosionParams { qsm_core::utils::SignalErosionParams::default() }
+fn se_threshold() -> f64 { se_default().threshold }
+fn se_depth_cap() -> usize { se_default().depth_cap }
+fn se_global_erosions() -> usize { se_default().global_erosions }
+fn se_bias_sigma() -> f64 { se_default().bias_sigma }
+fn se_min_component() -> usize { se_default().min_component }
+fn hd_bet_patch() -> [usize; 3] { let p = qsm_core::bet::HdBetParams::default().patch; [p.0, p.1, p.2] }
+/// `hd-bet:low-memory` patch — qsm-core's `HdBetParams::low_memory()` (~1.9 GB peak vs ~4.5 GB).
+pub fn hd_bet_low_memory_patch() -> [usize; 3] {
+    let p = qsm_core::bet::HdBetParams::low_memory().patch;
+    [p.0, p.1, p.2]
+}
+
+impl MaskOp {
+    /// Signal-gated erosion with qsm-core's defaults (the QSM-CI harmonization setting).
+    pub fn signal_erode_default() -> Self {
+        Self::SignalErode {
+            threshold: se_threshold(), depth_cap: se_depth_cap(), global_erosions: se_global_erosions(),
+            bias_sigma: se_bias_sigma(), min_component: se_min_component(),
+        }
+    }
+    /// HD-BET with the native (training-size) patch and no test-time augmentation.
+    pub fn hd_bet_default() -> Self { Self::HdBet { patch: hd_bet_patch(), tta: false } }
+    /// HD-BET's native (training-size) sliding-window patch `[x, y, z]`.
+    pub fn hd_bet_default_patch() -> [usize; 3] { hd_bet_patch() }
+    /// Whether this op creates a mask (as opposed to refining one).
+    pub fn is_generator(&self) -> bool {
+        matches!(self, Self::Threshold { .. } | Self::Bet { .. } | Self::HdBet { .. })
+    }
 }
 
 impl fmt::Display for MaskOp {
@@ -54,6 +101,13 @@ impl fmt::Display for MaskOp {
             Self::Close { radius } => write!(f, "close:{}", radius),
             Self::FillHoles { max_size } => write!(f, "fill-holes:{}", max_size),
             Self::GaussianSmooth { sigma_mm } => write!(f, "gaussian:{:.1}", sigma_mm),
+            Self::SignalErode { threshold, depth_cap, global_erosions, bias_sigma, min_component } =>
+                write!(f, "signal-erode:{:.2}:{}:{}:{:.1}:{}", threshold, depth_cap, global_erosions, bias_sigma, min_component),
+            Self::HdBet { patch, tta } => {
+                write!(f, "hd-bet:{}x{}x{}", patch[0], patch[1], patch[2])?;
+                if *tta { write!(f, ":tta")?; }
+                Ok(())
+            }
         }
     }
 }
@@ -68,7 +122,7 @@ pub struct MaskSection {
 
 impl MaskSection {
     pub fn has_generator(&self) -> bool {
-        matches!(self.generator, MaskOp::Threshold { .. } | MaskOp::Bet { .. })
+        self.generator.is_generator()
     }
     pub fn all_ops(&self) -> Vec<MaskOp> {
         let mut ops = vec![self.generator.clone()];
@@ -109,8 +163,18 @@ pub fn qsmart_default_mask_sections() -> Vec<MaskSection> {
     }]
 }
 
+/// HD-BET on the magnitude followed by signal-gated erosion — the QSM-CI harmonization masking
+/// (the `hd-bet` mask preset).
+pub fn hd_bet_mask_sections() -> Vec<MaskSection> {
+    vec![MaskSection {
+        input: MaskingInput::Magnitude,
+        generator: MaskOp::hd_bet_default(),
+        refinements: vec![MaskOp::signal_erode_default()],
+    }]
+}
+
 pub fn parse_mask_op(s: &str) -> crate::Result<MaskOp> {
-    let parts: Vec<&str> = s.splitn(3, ':').collect();
+    let parts: Vec<&str> = s.split(':').collect();
     match parts[0] {
         "threshold" => match parts.get(1).copied() {
             Some("otsu") | None => Ok(MaskOp::Threshold { method: MaskThresholdMethod::Otsu, value: None }),
@@ -124,7 +188,45 @@ pub fn parse_mask_op(s: &str) -> crate::Result<MaskOp> {
         "close" => Ok(MaskOp::Close { radius: parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(1) }),
         "fill-holes" => Ok(MaskOp::FillHoles { max_size: parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(1000) }),
         "gaussian" => Ok(MaskOp::GaussianSmooth { sigma_mm: parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(4.0) }),
+        "signal-erode" => {
+            let num = |i: usize, name: &str| -> crate::Result<Option<f64>> {
+                parts.get(i).filter(|s| !s.is_empty()).map(|s| s.parse::<f64>().map_err(|_| {
+                    ConfigError::Parse(format!("signal-erode: invalid {name} '{s}'"))
+                })).transpose()
+            };
+            let d = se_default();
+            Ok(MaskOp::SignalErode {
+                threshold: num(1, "threshold")?.unwrap_or(d.threshold),
+                depth_cap: num(2, "depth cap")?.map(|v| v as usize).unwrap_or(d.depth_cap),
+                global_erosions: num(3, "global erosions")?.map(|v| v as usize).unwrap_or(d.global_erosions),
+                bias_sigma: num(4, "bias sigma")?.unwrap_or(d.bias_sigma),
+                min_component: num(5, "min component")?.map(|v| v as usize).unwrap_or(d.min_component),
+            })
+        }
+        "hd-bet" => {
+            let mut patch = hd_bet_patch();
+            let mut tta = false;
+            for part in parts.iter().skip(1).filter(|p| !p.is_empty()) {
+                match *part {
+                    "tta" => tta = true,
+                    "native" => patch = hd_bet_patch(),
+                    "low-memory" => patch = hd_bet_low_memory_patch(),
+                    dims => patch = parse_hd_bet_patch(dims)?,
+                }
+            }
+            Ok(MaskOp::HdBet { patch, tta })
+        }
         _ => Err(ConfigError::Parse(format!("Unknown mask-op: '{}'", parts[0]))),
+    }
+}
+
+/// `XxYxZ` HD-BET patch; each size must be a multiple of the network's 32×32×16 down-sampling.
+fn parse_hd_bet_patch(s: &str) -> crate::Result<[usize; 3]> {
+    let dims: Vec<usize> = s.split('x').map(|d| d.trim().parse()).collect::<Result<_, _>>()
+        .map_err(|_| ConfigError::Parse(format!("hd-bet: expected a patch like 192x192x96, 'low-memory' or 'tta', got '{s}'")))?;
+    match dims[..] {
+        [x, y, z] if x > 0 && y > 0 && z > 0 && x % 32 == 0 && y % 32 == 0 && z % 16 == 0 => Ok([x, y, z]),
+        _ => Err(ConfigError::Parse(format!("hd-bet: patch '{s}' must be three sizes that are multiples of 32x32x16"))),
     }
 }
 
@@ -192,6 +294,48 @@ mod tests {
         if let MaskOp::GaussianSmooth { sigma_mm } = op {
             assert!((sigma_mm - 2.5).abs() < 1e-10);
         } else { panic!("wrong variant"); }
+    }
+
+    #[test]
+    fn test_parse_signal_erode() {
+        // Defaults match qsm-core's (the QSM-CI harmonization setting).
+        assert_eq!(parse_mask_op("signal-erode").unwrap(), MaskOp::signal_erode_default());
+        let op = parse_mask_op("signal-erode:0.7:3").unwrap();
+        let d = qsm_core::utils::SignalErosionParams::default();
+        assert_eq!(op, MaskOp::SignalErode {
+            threshold: 0.7, depth_cap: 3, global_erosions: d.global_erosions,
+            bias_sigma: d.bias_sigma, min_component: d.min_component,
+        });
+        assert!(parse_mask_op("signal-erode:abc").is_err());
+        // Display round-trips every parameter (it is the mask-stage cache key).
+        let full = parse_mask_op("signal-erode:0.75:4:0:10:500").unwrap();
+        assert_eq!(format!("{full}"), "signal-erode:0.75:4:0:10.0:500");
+        assert_eq!(parse_mask_op(&format!("{full}")).unwrap(), full);
+    }
+
+    #[test]
+    fn test_parse_hd_bet() {
+        assert_eq!(parse_mask_op("hd-bet").unwrap(), MaskOp::HdBet { patch: [192, 192, 96], tta: false });
+        assert_eq!(parse_mask_op("hd-bet:low-memory").unwrap(), MaskOp::HdBet { patch: [128, 128, 64], tta: false });
+        assert_eq!(parse_mask_op("hd-bet:160x160x128:tta").unwrap(), MaskOp::HdBet { patch: [160, 160, 128], tta: true });
+        assert!(parse_mask_op("hd-bet:100x100x100").is_err(), "not a multiple of 32x32x16");
+        assert!(parse_mask_op("hd-bet:big").is_err());
+        let op = MaskOp::HdBet { patch: [128, 128, 64], tta: true };
+        assert_eq!(format!("{op}"), "hd-bet:128x128x64:tta");
+        assert_eq!(parse_mask_op(&format!("{op}")).unwrap(), op);
+        assert!(op.is_generator());
+        assert!(!MaskOp::signal_erode_default().is_generator());
+    }
+
+    #[test]
+    fn test_new_ops_serde_defaults() {
+        // Config files may omit parameters; they take qsm-core's defaults.
+        let sec: MaskSection = toml::from_str(
+            "input = \"magnitude\"\ngenerator = { op = \"hd-bet\" }\nrefinements = [{ op = \"signal-erode\" }]\n",
+        ).unwrap();
+        assert_eq!(sec.generator, MaskOp::hd_bet_default());
+        assert_eq!(sec.refinements, vec![MaskOp::signal_erode_default()]);
+        assert_eq!(format!("{sec}"), "magnitude,hd-bet:192x192x96,signal-erode:0.80:5:1:12.0:1000");
     }
 
     #[test]

--- a/crates/qsmxt-config/src/methods.rs
+++ b/crates/qsmxt-config/src/methods.rs
@@ -257,6 +257,16 @@ const CITE_BET: Citation = Citation {
     text: "Smith, S.M. (2002). \"Fast robust automated brain extraction.\" *Human Brain Mapping*, 17(3):143-155. https://doi.org/10.1002/hbm.10062",
 };
 
+const CITE_HDBET: Citation = Citation {
+    key: "isensee2019",
+    text: "Isensee, F., Schell, M., Pflueger, I., et al. (2019). \"Automated brain extraction of multisequence MRI using artificial neural networks.\" *Human Brain Mapping*, 40(17):4952-4964. https://doi.org/10.1002/hbm.24750",
+};
+
+const CITE_QSMCI_SIGNAL_EROSION: Citation = Citation {
+    key: "qsmci",
+    text: "QSM-CI: signal-gated mask erosion (QSM-CI harmonization masking, `hd-bet-qsmci`). https://github.com/QSMxT/QSM-CI",
+};
+
 const CITE_BIPOLAR: Citation = Citation {
     key: "eckstein2021phd",
     text: "Eckstein, K. (2021). \"Advanced Methods for Quantitative Susceptibility Mapping and Susceptibility Weighted Imaging.\" PhD thesis, Medical University of Vienna. https://doi.org/10.34726/hss.2021.43447",
@@ -581,6 +591,13 @@ fn describe_masking(config: &PipelineConfig, sentences: &mut Vec<String>, citati
                 add_citation(citations, &CITE_BET);
                 format!("BET brain extraction (Smith, 2002; f={:.2}) of {}", fractional_intensity, input_desc)
             }
+            MaskOp::HdBet { patch, tta } => {
+                add_citation(citations, &CITE_HDBET);
+                format!(
+                    "HD-BET deep-learning brain extraction (Isensee et al., 2019; {}x{}x{}-voxel sliding-window patches{}) of {}",
+                    patch[0], patch[1], patch[2], if *tta { ", mirroring test-time augmentation" } else { "" }, input_desc,
+                )
+            }
             _ => format!("{} of {}", section.generator, input_desc),
         };
         parts.push(gen_desc);
@@ -593,6 +610,15 @@ fn describe_masking(config: &PipelineConfig, sentences: &mut Vec<String>, citati
             MaskOp::FillHoles { max_size: 0 } => "hole-filling".to_string(),
             MaskOp::FillHoles { max_size } => format!("hole-filling (max {} voxels)", max_size),
             MaskOp::GaussianSmooth { sigma_mm } => format!("Gaussian smoothing (sigma={:.1} mm)", sigma_mm),
+            MaskOp::SignalErode { threshold, depth_cap, global_erosions, .. } => {
+                add_citation(citations, &CITE_QSMCI_SIGNAL_EROSION);
+                let depth = if *depth_cap == 0 { "no depth limit".to_string() } else { format!("at most {} voxels deep", depth_cap) };
+                let global = if *global_erosions > 0 { format!("{} plain erosion{} then ", global_erosions, if *global_erosions != 1 { "s" } else { "" }) } else { String::new() };
+                format!(
+                    "signal-gated erosion ({}removal of boundary voxels below {:.2} of the median bias-corrected magnitude, {}; QSM-CI)",
+                    global, threshold, depth,
+                )
+            }
             _ => format!("{}", op),
         }).collect();
 
@@ -995,6 +1021,22 @@ mod tests {
         assert!(out.contains("BET brain extraction"));
         assert!(out.contains("Smith, 2002"));
         assert!(out.contains("f=0.35"));
+    }
+
+    #[test]
+    fn test_masking_hd_bet_signal_erode() {
+        let mut config = PipelineConfig::default();
+        config.masking.sections = vec![MaskSection {
+            input: MaskingInput::Magnitude,
+            generator: MaskOp::hd_bet_default(),
+            refinements: vec![MaskOp::signal_erode_default()],
+        }];
+        let out = generate_methods(&config);
+        assert!(out.contains("HD-BET deep-learning brain extraction (Isensee et al., 2019; 192x192x96"), "{out}");
+        assert!(out.contains("signal-gated erosion (1 plain erosion then removal of boundary voxels below 0.80"), "{out}");
+        assert!(out.contains("at most 5 voxels deep"), "{out}");
+        assert!(out.contains("https://doi.org/10.1002/hbm.24750"), "{out}");
+        assert!(out.contains("https://github.com/QSMxT/QSM-CI"), "{out}");
     }
 
     #[test]

--- a/docs/src/content/docs/guides/running-noninteractively.md
+++ b/docs/src/content/docs/guides/running-noninteractively.md
@@ -59,7 +59,7 @@ qsmxt run study/bids \
 | `--qsm-algorithm` | `rts`, `tv`, `tkd`, `tsvd`, `tgv`, `tikhonov`, `nltv`, `medi`, `ilsqr`, `qsmart` |
 | `--unwrapping-algorithm` | `romeo`, `laplacian` |
 | `--bf-algorithm` | `vsharp`, `pdf`, `lbv`, `ismv`, `sharp`, `resharp`, `harperella`, `iharperella` |
-| `--mask-preset` | `robust-threshold`, `bet` |
+| `--mask-preset` | `robust-threshold`, `bet`, `hd-bet` |
 | `--masking-input` | `magnitude-first`, `magnitude`, `magnitude-last`, `phase-quality` |
 
 `--masking-input` overrides the image the mask is computed from and combines

--- a/docs/src/content/docs/reference/algorithms.md
+++ b/docs/src/content/docs/reference/algorithms.md
@@ -16,6 +16,7 @@ operates on with `--masking-input`.
 | --- | --- |
 | `robust-threshold` | Otsu thresholding of the phase-quality map, refined with dilation, hole-filling and erosion (default) |
 | `bet` | Brain Extraction Tool on the magnitude image |
+| `hd-bet` | HD-BET deep-learning brain extraction on the magnitude image, followed by signal-gated erosion (the QSM-CI harmonization masking). Needs a deep-learning build; the weights (~120 MB, CC-BY-NC-4.0) are downloaded on first use |
 
 **Masking input** (`--masking-input`): `magnitude-first`, `magnitude`,
 `magnitude-last`, `phase-quality`. For example,
@@ -25,6 +26,23 @@ combined magnitude image instead of the phase-quality map.
 For full control, compose custom mask sections with `--mask` (repeatable),
 e.g. `--mask magnitude,bet:0.5,erode:2`. Each section names its input
 followed by a generator and refinement operations.
+
+- **Generators:** `threshold[:otsu|fixed:<v>|percentile:<p>]`, `bet[:<f>]`, and
+  `hd-bet[:<X>x<Y>x<Z>|low-memory][:tta]`. HD-BET runs 192×192×96 sliding-window
+  patches by default (about 4.5 GB peak). `low-memory` uses 128×128×64 patches
+  (about 1.9 GB peak), and `tta` adds mirroring test-time augmentation, which is
+  roughly 8× slower.
+- **Refinements:** `erode[:<n>]`, `dilate[:<n>]`, `close[:<r>]`, `fill-holes[:<max>]`,
+  `gaussian[:<sigma_mm>]`, and
+  `signal-erode[:<threshold>[:<depth_cap>[:<global_erosions>[:<bias_sigma>[:<min_component>]]]]]`.
+  `signal-erode` removes only boundary voxels whose bias-corrected magnitude is
+  below `threshold` × the in-mask median (default 0.80). It works inward through
+  sinus and skull-base signal dropout, never more than `depth_cap` voxels deep
+  (default 5), after `global_erosions` plain erosions (default 1). Dark interior
+  structures are never removed.
+
+For example, `--mask magnitude,hd-bet:low-memory,signal-erode` is the `hd-bet`
+preset with the low-memory patch size.
 
 ## Phase unwrapping
 

--- a/docs/src/content/docs/reference/commands.md
+++ b/docs/src/content/docs/reference/commands.md
@@ -54,7 +54,7 @@ qsmxt <cmd> --help # full help for a command
 | `--qsm-algorithm <A>` | Dipole inversion method |
 | `--unwrapping-algorithm <A>` | Phase unwrapping method |
 | `--bf-algorithm <A>` | Background field removal method |
-| `--mask-preset <P>` | Masking recipe (`robust-threshold`, `bet`) |
+| `--mask-preset <P>` | Masking recipe (`robust-threshold`, `bet`, `hd-bet`) |
 | `--mask <SECTION>` | Custom mask section, repeatable (e.g. `magnitude,bet:0.5,erode:2`) |
 | `--masking-input <A>` | Override the image the mask is derived from |
 | `--phase-offset-removal <bool>` | Multi-echo phase-offset removal |

--- a/docs/src/content/docs/reference/tools.md
+++ b/docs/src/content/docs/reference/tools.md
@@ -21,11 +21,16 @@ Generate or refine binary masks.
 | `value` | Fixed-value thresholding |
 | `percentile` | Percentile thresholding |
 | `bet` | Brain extraction (BET) |
+| `hd-bet` | Deep-learning brain extraction (HD-BET); `--low-memory`, `--patch XxYxZ`, `--tta`. Weights are downloaded on first use |
 | `robust` | Robust threshold (Otsu + dilate + fill-holes + erode) |
 | `erode` / `dilate` | Morphological erosion / dilation |
 | `close` | Morphological closing |
 | `fill-holes` | Fill holes in a binary mask |
 | `smooth` | Gaussian smooth (re-thresholded at 0.5) |
+
+The generating subcommands (`otsu`, `value`, `percentile`, `bet`, `hd-bet`) also
+accept `--op` refinements, applied in order, e.g. `--op erode:2` or
+`--op signal-erode` (signal-gated erosion, which uses the input magnitude).
 
 ## Phase unwrapping — `qsmxt unwrap`
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1049,7 +1049,8 @@ pub struct PipelineArgs {
     #[arg(long)]
     pub obliquity_threshold: Option<f64>,
 
-    /// Mask preset (robust-threshold or bet)
+    /// Mask preset: robust-threshold, bet, or hd-bet (HD-BET deep-learning brain extraction +
+    /// signal-gated erosion; needs a deep-learning build)
     #[arg(long, value_enum)]
     pub mask_preset: Option<MaskPresetArg>,
 
@@ -1063,6 +1064,8 @@ pub struct PipelineArgs {
     /// Format: <input>,<generator>,<refinement1>,<refinement2>,...
     /// Example: phase-quality,threshold:otsu,dilate:2,fill-holes:0,erode:2
     /// Example: magnitude,bet:0.5,erode:2
+    /// Example: magnitude,hd-bet,signal-erode   (HD-BET: `hd-bet[:XxYxZ|low-memory][:tta]`;
+    ///   signal-erode: `signal-erode[:threshold[:depth_cap[:global_erosions[:bias_sigma[:min_component]]]]]`)
     #[arg(long = "mask", num_args = 1)]
     pub mask_sections_cli: Option<Vec<String>>,
 }
@@ -1220,7 +1223,8 @@ pub struct MaskCommonArgs {
     #[arg(short, long)]
     pub output: PathBuf,
     /// Refinement operation (repeatable, applied in order).
-    /// Examples: erode:2, dilate:1, fill-holes:0, close:1, gaussian:4.0
+    /// Examples: erode:2, dilate:1, fill-holes:0, close:1, gaussian:4.0,
+    /// signal-erode (signal-gated erosion of low-signal boundary voxels; needs a magnitude input)
     #[arg(long = "op")]
     pub ops: Vec<String>,
 }
@@ -1235,6 +1239,8 @@ pub enum MaskCommand {
     Percentile(MaskPercentileArgs),
     /// Brain extraction (BET)
     Bet(MaskBetArgs),
+    /// Deep-learning brain extraction (HD-BET; downloads weights on first use)
+    HdBet(MaskHdBetArgs),
     /// Robust threshold (Otsu + dilate:1 + fill-holes:0 + erode:1)
     Robust(MaskRobustArgs),
     /// Erode a binary mask
@@ -1280,6 +1286,21 @@ pub struct MaskBetArgs {
     /// Fractional intensity (0.0-1.0, smaller = larger brain)
     #[arg(long, default_value_t = 0.5)]
     pub fractional_intensity: f64,
+}
+
+#[derive(Parser, Debug)]
+pub struct MaskHdBetArgs {
+    #[command(flatten)]
+    pub common: MaskCommonArgs,
+    /// Use 128x128x64 sliding-window patches (~1.9 GB peak instead of ~4.5 GB)
+    #[arg(long)]
+    pub low_memory: bool,
+    /// Sliding-window patch size XxYxZ in voxels at 1 mm (multiples of 32x32x16; default 192x192x96)
+    #[arg(long)]
+    pub patch: Option<String>,
+    /// 8-fold mirroring test-time augmentation (about 8x slower)
+    #[arg(long)]
+    pub tta: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -2681,5 +2702,5 @@ pub enum QsmReferenceArg {
 
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq)]
 pub enum MaskPresetArg {
-    RobustThreshold, Bet,
+    RobustThreshold, Bet, HdBet,
 }

--- a/src/commands/mask.rs
+++ b/src/commands/mask.rs
@@ -3,15 +3,17 @@ use super::common::{load_nifti, save_mask, run_mask_operation};
 use crate::cli::{MaskCommand, MaskCommonArgs};
 use crate::pipeline::config::{parse_mask_op, MaskOp};
 
-fn apply_ops(mut mask: Vec<u8>, ops: &[String], grid: &qsm_core::Grid) -> crate::Result<Vec<u8>> {
+/// Apply `--op` refinements in order. `magnitude` is the input image when it is one (the
+/// threshold/BET/HD-BET subcommands) — needed by `signal-erode`.
+fn apply_ops(mut mask: Vec<u8>, ops: &[String], grid: &qsm_core::Grid, magnitude: Option<&[f64]>) -> crate::Result<Vec<u8>> {
     for op_str in ops {
         let op = parse_mask_op(op_str)?;
-        mask = apply_mask_op(mask, &op, grid);
+        mask = apply_mask_op(mask, &op, grid, magnitude)?;
     }
     Ok(mask)
 }
 
-fn apply_mask_op(mut mask: Vec<u8>, op: &MaskOp, grid: &qsm_core::Grid) -> Vec<u8> {
+fn apply_mask_op(mut mask: Vec<u8>, op: &MaskOp, grid: &qsm_core::Grid, magnitude: Option<&[f64]>) -> crate::Result<Vec<u8>> {
     match op {
         MaskOp::Erode { iterations } => {
             mask = qsm_core::utils::erode_mask(&mask, grid, *iterations);
@@ -33,9 +35,32 @@ fn apply_mask_op(mut mask: Vec<u8>, op: &MaskOp, grid: &qsm_core::Grid) -> Vec<u
             );
             mask = smoothed.iter().map(|&v| if v > 0.5 { 1u8 } else { 0u8 }).collect();
         }
-        _ => {} // Threshold/Bet are generators, not refinements
+        MaskOp::SignalErode { threshold, depth_cap, global_erosions, bias_sigma, min_component } => {
+            let mag = magnitude.ok_or_else(|| crate::error::QsmxtError::Config(
+                "--op signal-erode needs the magnitude: use it with the otsu/value/percentile/bet/hd-bet \
+                 subcommands, whose input is the magnitude image".into(),
+            ))?;
+            let params = qsm_core::utils::SignalErosionParams {
+                threshold: *threshold, depth_cap: *depth_cap, global_erosions: *global_erosions,
+                bias_sigma: *bias_sigma, min_component: *min_component,
+            };
+            mask = qsm_core::utils::signal_gated_erosion(&mask, mag, grid, &params);
+        }
+        MaskOp::Threshold { .. } | MaskOp::Bet { .. } | MaskOp::HdBet { .. } => {
+            return Err(crate::error::QsmxtError::Config(format!(
+                "--op {op} creates a mask rather than refining one; use the matching `qsmxt mask` subcommand",
+            )));
+        }
     }
-    mask
+    Ok(mask)
+}
+
+/// The HD-BET op for `qsmxt mask hd-bet` (`--patch` wins over `--low-memory`).
+fn hd_bet_op(args: &crate::cli::MaskHdBetArgs) -> crate::Result<MaskOp> {
+    let mut spec = String::from("hd-bet");
+    if let Some(p) = &args.patch { spec += &format!(":{p}"); } else if args.low_memory { spec += ":low-memory"; }
+    if args.tta { spec += ":tta"; }
+    Ok(parse_mask_op(&spec)?)
 }
 
 pub fn execute(cmd: MaskCommand) -> crate::Result<()> {
@@ -46,14 +71,14 @@ pub fn execute(cmd: MaskCommand) -> crate::Result<()> {
             let t = qsm_core::utils::otsu_threshold(&nifti.data, 256);
             info!("Otsu threshold: {:.4}", t);
             let mask: Vec<u8> = nifti.data.iter().map(|&v| if v > t { 1u8 } else { 0u8 }).collect();
-            let mask = apply_ops(mask, &args.common.ops, &grid)?;
+            let mask = apply_ops(mask, &args.common.ops, &grid, Some(&nifti.data))?;
             save_and_log(&args.common, &mask, &nifti)
         }
         MaskCommand::Value(args) => {
             let nifti = load_nifti(&args.common.input)?;
             let grid = super::common::nifti_grid(&nifti);
             let mask: Vec<u8> = nifti.data.iter().map(|&v| if v > args.threshold { 1u8 } else { 0u8 }).collect();
-            let mask = apply_ops(mask, &args.common.ops, &grid)?;
+            let mask = apply_ops(mask, &args.common.ops, &grid, Some(&nifti.data))?;
             save_and_log(&args.common, &mask, &nifti)
         }
         MaskCommand::Percentile(args) => {
@@ -65,7 +90,7 @@ pub fn execute(cmd: MaskCommand) -> crate::Result<()> {
             let t = sorted[idx.min(sorted.len() - 1)];
             info!("Percentile {:.1}% threshold: {:.4}", args.percentile, t);
             let mask: Vec<u8> = nifti.data.iter().map(|&v| if v > t { 1u8 } else { 0u8 }).collect();
-            let mask = apply_ops(mask, &args.common.ops, &grid)?;
+            let mask = apply_ops(mask, &args.common.ops, &grid, Some(&nifti.data))?;
             save_and_log(&args.common, &mask, &nifti)
         }
         MaskCommand::Bet(args) => {
@@ -77,7 +102,28 @@ pub fn execute(cmd: MaskCommand) -> crate::Result<()> {
                 ..qsm_core::bet::BetParams::default()
             };
             let mask = qsm_core::bet::run_bet(&nifti.data, &grid, &params, |_, _| {});
-            let mask = apply_ops(mask, &args.common.ops, &grid)?;
+            let mask = apply_ops(mask, &args.common.ops, &grid, Some(&nifti.data))?;
+            save_and_log(&args.common, &mask, &nifti)
+        }
+        MaskCommand::HdBet(args) => {
+            let nifti = load_nifti(&args.common.input)?;
+            let grid = super::common::nifti_grid(&nifti);
+            let op = hd_bet_op(&args)?;
+            // Fetch the weights (with a progress bar), or fail clearly on a build without `dl`.
+            crate::pipeline::runner::prefetch_weights("hd-bet", "hd-bet")?;
+            info!("Running HD-BET ({})", op);
+            let section = crate::pipeline::config::MaskSection {
+                input: crate::pipeline::config::MaskingInput::Magnitude,
+                generator: op,
+                refinements: vec![],
+            };
+            let core = crate::pipeline::config::to_mask_sections(&[section]);
+            let meta = crate::pipeline::config::to_scan_metadata(
+                (grid.nx(), grid.ny(), grid.nz()), grid.voxel_size, &[], 0.0, (0.0, 0.0, 1.0),
+            );
+            let mask = qsm_core::pipeline::run_masking(&core, &[], Some(&nifti.data), &meta)
+                .map_err(|e| crate::error::QsmxtError::Config(format!("HD-BET: {e}")))?;
+            let mask = apply_ops(mask, &args.common.ops, &grid, Some(&nifti.data))?;
             save_and_log(&args.common, &mask, &nifti)
         }
         MaskCommand::Robust(args) => {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -185,6 +185,63 @@ mod integration_tests {
         assert!(output.exists());
     }
 
+    #[test]
+    fn test_mask_signal_erode_op() {
+        // signal-erode refines a threshold mask using the (magnitude) input image.
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("mag.nii");
+        let output = dir.path().join("mask.nii");
+        testutils::write_magnitude(&input);
+        let mut c = common_mask(input, output.clone());
+        c.ops = vec!["signal-erode:0.8:2:0:4:1".to_string()];
+        super::mask::execute(MaskCommand::Otsu(MaskOtsuArgs { common: c })).unwrap();
+        assert!(output.exists());
+    }
+
+    #[test]
+    fn test_mask_generator_op_is_rejected() {
+        // A generator passed as --op used to be silently ignored.
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("mag.nii");
+        testutils::write_magnitude(&input);
+        for op in ["bet:0.5", "hd-bet", "threshold:otsu"] {
+            let mut c = common_mask(input.clone(), dir.path().join("mask.nii"));
+            c.ops = vec![op.to_string()];
+            let err = super::mask::execute(MaskCommand::Otsu(MaskOtsuArgs { common: c })).unwrap_err();
+            assert!(format!("{err}").contains("creates a mask"), "{op}: {err}");
+        }
+    }
+
+    #[cfg(not(feature = "dl"))]
+    #[test]
+    fn test_mask_hd_bet_needs_dl() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("mag.nii");
+        testutils::write_magnitude(&input);
+        let err = super::mask::execute(MaskCommand::HdBet(MaskHdBetArgs {
+            common: common_mask(input, dir.path().join("mask.nii")),
+            low_memory: false, patch: None, tta: false,
+        })).unwrap_err();
+        assert!(format!("{err}").contains("deep-learning"), "{err}");
+    }
+
+    /// Runs HD-BET for real (downloads the ~120 MB weights on first use).
+    #[cfg(feature = "dl")]
+    #[test]
+    #[ignore]
+    fn test_mask_hd_bet() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("mag.nii");
+        let output = dir.path().join("mask.nii");
+        testutils::write_magnitude(&input);
+        let mut c = common_mask(input, output.clone());
+        c.ops = vec!["signal-erode".to_string()];
+        super::mask::execute(MaskCommand::HdBet(MaskHdBetArgs {
+            common: c, low_memory: true, patch: None, tta: false,
+        })).unwrap();
+        assert!(output.exists());
+    }
+
     // --- Mask: percentile, robust, erode ---
 
     #[test]

--- a/src/pipeline/config.rs
+++ b/src/pipeline/config.rs
@@ -389,6 +389,7 @@ pub fn apply_run_overrides(config: &mut PipelineConfig, args: &cli::PipelineArgs
                     generator: MaskOp::Bet { fractional_intensity: 0.5 },
                     refinements: vec![MaskOp::Erode { iterations: 2 }],
                 }],
+                cli::MaskPresetArg::HdBet => hd_bet_mask_sections(),
             };
         }
         if let Some(ref sections) = args.mask_sections_cli {
@@ -407,7 +408,7 @@ pub fn apply_run_overrides(config: &mut PipelineConfig, args: &cli::PipelineArgs
                         Err(e) => log::warn!("Ignoring invalid mask op '{}': {}", part, e),
                     }
                 }
-                let gen_idx = ops.iter().position(|op| matches!(op, MaskOp::Threshold { .. } | MaskOp::Bet { .. }));
+                let gen_idx = ops.iter().position(MaskOp::is_generator);
                 let generator = if let Some(gi) = gen_idx { ops.remove(gi) } else {
                     MaskOp::Threshold { method: MaskThresholdMethod::Otsu, value: None }
                 };
@@ -446,10 +447,10 @@ pub fn apply_run_overrides(config: &mut PipelineConfig, args: &cli::PipelineArgs
             if untouched {
                 log::info!("QSMART: defaulting to BET brain mask (override with --mask)");
                 config.masking.sections = qsmart_default_mask_sections();
-            } else if !config.masking.sections.iter().all(|s| matches!(s.generator, MaskOp::Bet { .. })) {
+            } else if !config.masking.sections.iter().all(|s| matches!(s.generator, MaskOp::Bet { .. } | MaskOp::HdBet { .. })) {
                 log::warn!(
-                    "QSMART needs a tight brain mask; the configured mask is not BET-based and \
-                     may cause streaking artifacts. Consider --mask-preset bet or \
+                    "QSMART needs a tight brain mask; the configured mask is not BET- or HD-BET-based and \
+                     may cause streaking artifacts. Consider --mask-preset bet, --mask-preset hd-bet or \
                      --mask magnitude,bet:0.5,erode:2."
                 );
             }
@@ -577,6 +578,18 @@ mod tests {
         let d = default_mask_sections();
         assert_eq!(c.masking.sections[0].generator, d[0].generator);
         assert_eq!(c.masking.sections[0].refinements, d[0].refinements);
+    }
+
+    #[test]
+    fn hd_bet_mask_preset_and_sections() {
+        let c = config_from_cli(&["qsmxt", "run", "<bids>", "--mask-preset", "hd-bet"]);
+        assert_eq!(c.masking.sections, hd_bet_mask_sections());
+        // --mask: hd-bet is recognised as the generator wherever it appears in the section.
+        let c = config_from_cli(&[
+            "qsmxt", "run", "<bids>", "--mask", "magnitude,signal-erode:0.7,hd-bet:low-memory",
+        ]);
+        assert_eq!(c.masking.sections[0].generator, MaskOp::HdBet { patch: [128, 128, 64], tta: false });
+        assert!(matches!(c.masking.sections[0].refinements[..], [MaskOp::SignalErode { threshold, .. }] if threshold == 0.7));
     }
 
     #[test]

--- a/src/pipeline/memory.rs
+++ b/src/pipeline/memory.rs
@@ -47,7 +47,18 @@ pub fn estimate_peak_memory_bytes(
     // Masking stage (temporary) — worst case across all sections
     // BET is the most expensive: sorted nonzero vec (~N*8) + within_brain values (~N*8) + output (N)
     let has_bet = config.masking.sections.iter().any(|s| matches!(s.generator, MaskOp::Bet { .. }));
-    let mask_mem = if has_bet { 17 * n } else { 9 * n };
+    // HD-BET: tract activations for one sliding-window patch (~1 KiB per patch voxel), the parsed
+    // model (~300 MB), and its f32 working volumes (~40 B/voxel). Measured on 164×205×205:
+    // ~3.6–4.5 GB with the native 192×192×96 patch, ~1.5–1.9 GB with the 128×128×64 one.
+    let hd_bet_mem = config.masking.sections.iter()
+        .filter_map(|s| match &s.generator { MaskOp::HdBet { patch, .. } => Some(patch.iter().product::<usize>()), _ => None })
+        .max()
+        .map_or(0, |patch_voxels| patch_voxels * 1024 + 300 * 1024 * 1024 + 40 * n);
+    // Signal-gated erosion keeps a handful of f64 volumes (smoothed signal, bias estimate, depth).
+    let has_signal_erode = config.masking.sections.iter()
+        .any(|s| s.refinements.iter().any(|op| matches!(op, MaskOp::SignalErode { .. })));
+    let mask_mem = (if has_bet { 17 * n } else { 9 * n }).max(hd_bet_mem)
+        + if has_signal_erode { 8 * n * F64 } else { 0 };
 
     // SWI runs before QSM; its outputs persist through QSM stages
     let swi_persistent = if config.pipeline.do_swi { 16 * n } else { 0 }; // swi + mip results
@@ -311,6 +322,20 @@ mod tests {
             c.bg_removal.algorithm = b;
             assert!(estimate_peak_memory_bytes(8, 8, 8, 1, false, &c) > 0, "{:?}", b);
         }
+    }
+
+    #[test]
+    fn test_hd_bet_mask_memory() {
+        use crate::pipeline::config::{hd_bet_mask_sections, MaskOp};
+        let mut c = default_config();
+        let base = estimate_peak_memory_bytes(164, 205, 205, 4, true, &c);
+        c.masking.sections = hd_bet_mask_sections();
+        let native = estimate_peak_memory_bytes(164, 205, 205, 4, true, &c);
+        c.masking.sections[0].generator = MaskOp::HdBet { patch: [128, 128, 64], tta: false };
+        let low = estimate_peak_memory_bytes(164, 205, 205, 4, true, &c);
+        // The native patch dominates the pipeline peak (measured ~3.6–4.5 GB for masking alone).
+        assert!(native > 3_500_000_000 && native > base, "native {native}, base {base}");
+        assert!(low < native, "low-memory patch ({low}) should estimate below native ({native})");
     }
 
     #[test]

--- a/src/pipeline/runner.rs
+++ b/src/pipeline/runner.rs
@@ -675,6 +675,12 @@ fn stage_mask(ctx: &mut StageContext, mask_path: &Path, progress: &dyn Fn(&str))
     );
     let phase_refs: Vec<&[f64]> = phases.iter().map(|p| p.as_slice()).collect();
 
+    // Deep-learning mask ops (HD-BET): fetch the weights first, with a progress bar — or fail
+    // clearly on a build without the `dl` feature.
+    for id in core_sections.iter().flat_map(|s| s.all_ops()).filter_map(|op| op.dl_model_id()) {
+        prefetch_weights(id, &ctx.run.key.to_string())?;
+    }
+
     let working_mask = qsm_core::pipeline::run_masking(
         &core_sections, &phase_refs, mag_data.as_deref(), &scan_meta,
     ).map_err(|e| QsmxtError::Config(format!("masking: {}", e)))?;
@@ -1623,6 +1629,17 @@ mod tests {
     fn test_prefetch_weights_errors_for_dl_without_dl_feature() {
         // Selecting a DL model in a non-DL build must fail with a clear message.
         let err = super::prefetch_weights("qsmnet", "test").unwrap_err();
+        assert!(format!("{}", err).contains("deep-learning"), "got: {}", err);
+    }
+
+    #[cfg(not(feature = "dl"))]
+    #[test]
+    fn test_hd_bet_mask_needs_dl_feature() {
+        // The mask stage prefetches every DL op's weights; HD-BET must hit the same clear error.
+        let sections = crate::pipeline::config::to_mask_sections(&crate::pipeline::config::hd_bet_mask_sections());
+        let ids: Vec<&str> = sections.iter().flat_map(|s| s.all_ops()).filter_map(|op| op.dl_model_id()).collect();
+        assert_eq!(ids, ["hd-bet"]);
+        let err = super::prefetch_weights(ids[0], "test").unwrap_err();
         assert!(format!("{}", err).contains("deep-learning"), "got: {}", err);
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -893,15 +893,22 @@ pub enum PipelineRow {
 }
 
 pub const MASK_OP_TYPES: &[&str] = &[
-    "threshold", "bet", "erode", "dilate", "close", "fill-holes", "gaussian",
+    "threshold", "bet", "hd-bet", "erode", "dilate", "close", "fill-holes", "gaussian", "signal-erode",
 ];
 
-pub const MASK_PRESET_OPTIONS: &[&str] = &["robust-threshold", "bet", "custom"];
+/// Ops that create a mask (the section's generator); the rest are refinements.
+pub const MASK_GENERATOR_TYPES: &[&str] = &["threshold", "bet", "hd-bet"];
+
+pub const MASK_PRESET_OPTIONS: &[&str] = &["robust-threshold", "bet", "hd-bet", "custom"];
 pub const MASK_PRESET_HELP: &[&str] = &[
     "Otsu threshold + dilate + fill holes + erode (recommended for brain)",
     "BET brain extraction + erode",
+    "HD-BET deep-learning brain extraction + signal-gated erosion (QSM-CI harmonization masking)",
     "Fully custom mask pipeline (edit steps below)",
 ];
+/// Index of the "custom" preset — set automatically when the steps are edited by hand, and
+/// skipped when cycling presets with ←/→.
+pub const MASK_PRESET_CUSTOM: usize = 3;
 
 // ─── Algorithm help text (name + DOI) ───
 
@@ -1190,7 +1197,7 @@ pub struct PipelineFormState {
 
     // Mask sections (OR'd together at runtime)
     pub mask_sections: Vec<crate::pipeline::config::MaskSection>,
-    pub mask_preset: usize, // 0=robust threshold, 1=BET, 2=custom
+    pub mask_preset: usize, // index into MASK_PRESET_OPTIONS (MASK_PRESET_CUSTOM = hand-edited)
     pub custom_mask_tool: String, // empty=off; "*"=any derivatives tool; else a tool name
 
     // Separation tab
@@ -2642,6 +2649,10 @@ impl PipelineFormState {
             MaskOp::Close { radius } => ("close", format!("{}", radius)),
             MaskOp::FillHoles { max_size } => ("fill-holes", if *max_size == 0 { "auto".to_string() } else { format!("{}", max_size) }),
             MaskOp::GaussianSmooth { sigma_mm } => ("gaussian", format!("{}", sigma_mm)),
+            MaskOp::HdBet { patch, tta } =>
+                ("hd-bet", format!("{}x{}x{}{}", patch[0], patch[1], patch[2], if *tta { " tta" } else { "" })),
+            MaskOp::SignalErode { threshold, depth_cap, .. } =>
+                ("signal-erode", format!("{:.2} (depth {})", threshold, depth_cap)),
         }
     }
 
@@ -2656,6 +2667,9 @@ impl PipelineFormState {
             MaskOp::Close { .. } => "Morphological close radius (←/→ to adjust)",
             MaskOp::FillHoles { .. } => "Fill holes max size (0=auto, Enter to edit)",
             MaskOp::GaussianSmooth { .. } => "Gaussian sigma in mm (Enter to edit)",
+            MaskOp::HdBet { .. } => "HD-BET deep-learning brain extraction (needs a deep-learning build)",
+            MaskOp::SignalErode { .. } =>
+                "Signal-gated erosion: peel low-signal boundary voxels (threshold as fraction of median, ←/→ to adjust)",
         }
     }
 
@@ -2670,6 +2684,8 @@ impl PipelineFormState {
             "close" => Some(MaskOp::Close { radius: 1 }),
             "fill-holes" => Some(MaskOp::FillHoles { max_size: 0 }),
             "gaussian" => Some(MaskOp::GaussianSmooth { sigma_mm: 4.0 }),
+            "hd-bet" => Some(MaskOp::hd_bet_default()),
+            "signal-erode" => Some(MaskOp::signal_erode_default()),
             _ => None,
         }
     }
@@ -2688,33 +2704,33 @@ impl PipelineFormState {
                     refinements: vec![MaskOp::Erode { iterations: 2 }],
                 }];
             }
-            2 => { /* Custom: don't touch sections */ }
-            _ => {}
+            2 => { // HD-BET + signal-gated erosion
+                self.mask_sections = hd_bet_mask_sections();
+            }
+            _ => { /* Custom: don't touch sections */ }
         }
     }
 
     /// Mark preset as "Custom" when user manually edits mask sections.
     fn mark_mask_custom(&mut self) {
-        if self.mask_preset != 2 {
-            self.mask_preset = 2;
+        if self.mask_preset != MASK_PRESET_CUSTOM {
+            self.mask_preset = MASK_PRESET_CUSTOM;
         }
     }
 
-    /// Adjust the generator of a mask section (switch between threshold and BET).
+    /// Index of a section's generator in [`MASK_GENERATOR_TYPES`].
+    pub fn mask_generator_index(&self, section: usize) -> usize {
+        self.mask_sections.get(section)
+            .and_then(|s| MASK_GENERATOR_TYPES.iter().position(|&t| t == Self::mask_op_label_value(&s.generator).0))
+            .unwrap_or(0)
+    }
+
+    /// Cycle the generator of a mask section (threshold → BET → HD-BET) with left/right.
     pub fn adjust_mask_generator(&mut self, section: usize, delta: isize) {
-        use crate::pipeline::config::*;
         if section >= self.mask_sections.len() { return; }
-        let gen = &self.mask_sections[section].generator;
-        let new_gen = match gen {
-            MaskOp::Threshold { .. } if delta > 0 => MaskOp::Bet { fractional_intensity: 0.5 },
-            MaskOp::Bet { .. } if delta < 0 => MaskOp::Threshold { method: MaskThresholdMethod::Otsu, value: None },
-            // Also handle wrapping
-            MaskOp::Threshold { .. } => MaskOp::Bet { fractional_intensity: 0.5 },
-            MaskOp::Bet { .. } => MaskOp::Threshold { method: MaskThresholdMethod::Otsu, value: None },
-            _ => return,
-        };
-        self.mask_sections[section].generator = new_gen;
-        self.mark_mask_custom();
+        let n = MASK_GENERATOR_TYPES.len() as isize;
+        let new = (self.mask_generator_index(section) as isize + delta).rem_euclid(n) as usize;
+        self.set_mask_generator(section, new);
     }
 
     /// Adjust the generator's parameter (threshold method or BET fractional intensity).
@@ -2730,6 +2746,11 @@ impl PipelineFormState {
             }
             MaskOp::Bet { fractional_intensity } => {
                 *fractional_intensity = (*fractional_intensity + delta as f64 * 0.05).clamp(0.05, 1.0);
+            }
+            // Toggle between the native patch and the low-memory one.
+            MaskOp::HdBet { patch, .. } => {
+                let low = crate::pipeline::config::hd_bet_low_memory_patch();
+                *patch = if *patch == low { MaskOp::hd_bet_default_patch() } else { low };
             }
             _ => {}
         }
@@ -2758,22 +2779,13 @@ impl PipelineFormState {
         }
     }
 
-    /// Set a section's generator algorithm by index (0 = threshold, 1 = BET). Only rewrites the
-    /// generator when the algorithm type actually changes, preserving existing parameters.
+    /// Set a section's generator algorithm by index into [`MASK_GENERATOR_TYPES`]. Only rewrites
+    /// the generator when the algorithm type actually changes, preserving existing parameters.
     pub fn set_mask_generator(&mut self, section: usize, idx: usize) {
-        use crate::pipeline::config::*;
-        if section >= self.mask_sections.len() { return; }
-        let is_threshold = matches!(self.mask_sections[section].generator, MaskOp::Threshold { .. });
-        match idx {
-            0 if !is_threshold => {
-                self.mask_sections[section].generator = MaskOp::Threshold { method: MaskThresholdMethod::Otsu, value: None };
-                self.mark_mask_custom();
-            }
-            1 if is_threshold => {
-                self.mask_sections[section].generator = MaskOp::Bet { fractional_intensity: 0.5 };
-                self.mark_mask_custom();
-            }
-            _ => {}
+        if section >= self.mask_sections.len() || idx == self.mask_generator_index(section) { return; }
+        if let Some(op) = MASK_GENERATOR_TYPES.get(idx).and_then(|t| Self::default_mask_op(t)) {
+            self.mask_sections[section].generator = op;
+            self.mark_mask_custom();
         }
     }
 
@@ -2848,6 +2860,10 @@ impl PipelineFormState {
             MaskOp::GaussianSmooth { sigma_mm } => {
                 *sigma_mm = (*sigma_mm + delta as f64 * 0.5).max(0.5);
             }
+            MaskOp::HdBet { .. } => {}
+            MaskOp::SignalErode { threshold, .. } => {
+                *threshold = ((*threshold + delta as f64 * 0.05).clamp(0.05, 0.95) * 100.0).round() / 100.0;
+            }
         }
         self.mark_mask_custom();
     }
@@ -2856,7 +2872,7 @@ impl PipelineFormState {
     pub fn available_op_types(&self, _section: usize) -> Vec<&'static str> {
         // Generator is fixed — only offer morphological refinement ops
         MASK_OP_TYPES.iter()
-            .filter(|&&t| t != "threshold" && t != "bet")
+            .filter(|t| !MASK_GENERATOR_TYPES.contains(t))
             .copied()
             .collect()
     }
@@ -4462,19 +4478,16 @@ impl App {
                             cursor: ps.mask_input_index(*section),
                         }),
                         Some(PipelineRow::MaskOpGenerator { section }) => {
-                            let is_threshold = matches!(
-                                ps.mask_sections.get(*section).map(|s| &s.generator),
-                                Some(crate::pipeline::config::MaskOp::Threshold { .. })
-                            );
                             Some(AlgoModal {
                                 target: AlgoModalTarget::MaskGenerator(*section),
                                 title: "Mask Algorithm".to_string(),
-                                options: vec!["threshold".to_string(), "bet".to_string()],
+                                options: MASK_GENERATOR_TYPES.iter().map(|t| t.to_string()).collect(),
                                 help: vec![
                                     "Intensity threshold-based masking".to_string(),
                                     "FSL BET brain extraction".to_string(),
+                                    "HD-BET deep-learning brain extraction (Isensee et al., 2019)".to_string(),
                                 ],
-                                cursor: if is_threshold { 0 } else { 1 },
+                                cursor: ps.mask_generator_index(*section),
                             })
                         }
                         // Threshold method is a discrete select → modal. (BET frac. intensity is a
@@ -4618,8 +4631,8 @@ impl App {
                     let focus_idx = focusable.get(ps.focus).copied().unwrap_or(0);
                     match rows.get(focus_idx) {
                         Some(PipelineRow::AlgoSelect { field, options, .. }) => {
-                            // Mask preset: only cycle between 0 (robust) and 1 (bet); "custom" is auto-set
-                            let n = if *field == "mask_preset" { 2 } else { options.len() } as isize;
+                            // Mask preset: cycle the real presets only; "custom" is auto-set on edits
+                            let n = if *field == "mask_preset" { MASK_PRESET_CUSTOM } else { options.len() } as isize;
                             let cur = ps.get_select(field).min((n - 1) as usize) as isize;
                             let new_val = (cur + delta).rem_euclid(n) as usize;
                             ps.set_select(field, new_val);
@@ -7357,6 +7370,11 @@ mod tests {
         assert_eq!(app.pipeline_state.mask_preset, 0); // robust threshold
         app.handle_key(key(KeyCode::Right));
         assert_eq!(app.pipeline_state.mask_preset, 1); // BET
+        app.handle_key(key(KeyCode::Right));
+        assert_eq!(app.pipeline_state.mask_preset, 2); // HD-BET + signal-gated erosion
+        assert_eq!(app.pipeline_state.mask_sections, crate::pipeline::config::hd_bet_mask_sections());
+        app.handle_key(key(KeyCode::Right));
+        assert_eq!(app.pipeline_state.mask_preset, 0, "cycling skips 'custom'");
     }
 
     #[test]
@@ -7549,16 +7567,26 @@ mod tests {
         }
         let fi = gen_focus.expect("MaskOpGenerator not found");
         app.pipeline_state.focus = fi;
-        // Switch generator threshold <-> bet
+        // Cycle generator threshold -> bet -> hd-bet -> threshold (and back with Left)
         app.handle_key(key(KeyCode::Right));
         assert!(matches!(
             app.pipeline_state.mask_sections[0].generator,
             crate::pipeline::config::MaskOp::Bet { .. }
         ));
-        app.handle_key(key(KeyCode::Left));
+        app.handle_key(key(KeyCode::Right));
+        assert!(matches!(
+            app.pipeline_state.mask_sections[0].generator,
+            crate::pipeline::config::MaskOp::HdBet { .. }
+        ));
+        app.handle_key(key(KeyCode::Right));
         assert!(matches!(
             app.pipeline_state.mask_sections[0].generator,
             crate::pipeline::config::MaskOp::Threshold { .. }
+        ));
+        app.handle_key(key(KeyCode::Left));
+        assert!(matches!(
+            app.pipeline_state.mask_sections[0].generator,
+            crate::pipeline::config::MaskOp::HdBet { .. }
         ));
     }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -157,7 +157,7 @@ fn is_deep_learning_algo(name: &str) -> bool {
         name,
         "xqsm" | "qsmnet" | "qsmnet-plus" | "autoqsm" | "qsmgan" | "ir2qsm" | "lpcnn"
             | "modl-qsm" | "nextqsm" | "iqsm" | "iqsm-plus" | "bfrnet" | "iqfm"
-            | "susep-net" | "chi-sepnet"
+            | "susep-net" | "chi-sepnet" | "hd-bet"
     )
 }
 
@@ -1345,6 +1345,7 @@ fn draw_pipeline_tab(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) 
                 let algo_name = match gen {
                     crate::pipeline::config::MaskOp::Threshold { .. } => "threshold",
                     crate::pipeline::config::MaskOp::Bet { .. } => "bet",
+                    crate::pipeline::config::MaskOp::HdBet { .. } => "hd-bet",
                     _ => "?",
                 };
                 let label_style = if focused {
@@ -1354,7 +1355,7 @@ fn draw_pipeline_tab(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) 
                 };
                 if focused {
                     if focused_help.is_none() {
-                        focused_help = Some("Mask algorithm (←/→ to switch between threshold and BET)".to_string());
+                        focused_help = Some("Mask algorithm (←/→ to switch between threshold, BET and HD-BET)".to_string());
                     }
                     Line::from(vec![
                         Span::styled(format!("  {:22}", "Algorithm:"), label_style),
@@ -1387,6 +1388,11 @@ fn draw_pipeline_tab(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) 
                     }
                     crate::pipeline::config::MaskOp::Bet { fractional_intensity } => {
                         ("Frac. Intensity:", format!("{:.2}", fractional_intensity), "BET fractional intensity 0.0-1.0, smaller = larger brain (←/→ to adjust)")
+                    }
+                    crate::pipeline::config::MaskOp::HdBet { patch, .. } => {
+                        let low = *patch == crate::pipeline::config::hd_bet_low_memory_patch();
+                        ("Patch:", format!("{}x{}x{}{}", patch[0], patch[1], patch[2], if low { " (low memory)" } else { "" }),
+                         "HD-BET sliding-window patch: native ~4.5 GB peak, low memory ~1.9 GB (←/→ to toggle)")
                     }
                     _ => ("?:", "?".to_string(), ""),
                 };


### PR DESCRIPTION
Bumps `qsm-core` to [QSM.rs v0.31.0](https://github.com/astewartau/QSM.rs/releases/tag/v0.31.0) and exposes the two new masking operations it adds. The release also brings multithreaded ONNX inference (tract 0.23), which needs no code changes here: every deep-learning model in a `parallel` build now spreads each inference across cores (up to ~3× where inference dominates).

## New masking operations

**`hd-bet[:XxYxZ|low-memory][:tta]`** — HD-BET deep-learning brain extraction (Isensee et al., 2019) on the magnitude. Native 192×192×96 sliding-window patches (about 4.5 GB peak) or `low-memory` 128×128×64 (about 1.9 GB); `tta` adds mirroring test-time augmentation at roughly 8× the runtime. The weights (~120 MB, **CC-BY-NC-4.0**) are fetched with the usual progress bar before masking runs; a build without the `dl` feature fails with the standard "not in this build" message.

**`signal-erode[:threshold[:depth_cap[:global_erosions[:bias_sigma[:min_component]]]]]`** — QSM-CI's signal-gated erosion, a refinement for any mask. It removes only boundary voxels whose coil-debiased magnitude is below `threshold` × the in-mask median (default 0.80), working inward through sinus and skull-base dropout but never deeper than `depth_cap` voxels (default 5). Dark interior structures (veins, iron-rich nuclei) are left alone. Defaults come from qsm-core, so the two can't drift apart.

## Where they show up
- **`--mask-preset hd-bet`** — HD-BET followed by signal-gated erosion, i.e. QSM-CI's harmonization masking.
- **`--mask` sections** — e.g. `--mask magnitude,hd-bet:low-memory,signal-erode`.
- **`qsmxt mask hd-bet`** — with `--low-memory`, `--patch XxYxZ` and `--tta`.
- **`--op signal-erode`** — on the mask subcommands whose input is a magnitude image (`otsu`, `value`, `percentile`, `bet`, `hd-bet`).
- **TUI** — an HD-BET preset; the mask generator now cycles threshold → BET → HD-BET, with its parameter row toggling native / low-memory patches; signal-erode is available as a refinement step, its threshold adjustable with ←/→.
- **Config, methods text, memory estimate, docs** — both ops serialise to TOML with every parameter optional; the methods text describes them and cites Isensee et al. (2019) and QSM-CI; the memory estimator accounts for HD-BET's patch size and signal-erode's working volumes.

## Behaviour change
Passing a generator to `--op` (e.g. `--op bet:0.5`) is now an error instead of being silently ignored.

## Verification
- **End to end:** `qsmxt run ~/bids --mask-preset hd-bet` on the qsm-forward phantom produces a mask at **Dice 0.965** against ground truth, matching the QSM.rs/QSM-CI reference for HD-BET plus signal-gated erosion, with correct methods text and serialised config. Masking took 127 s.
- **Tests:** workspace tests pass (565 + 105); the `--no-default-features` build passes (568), including the no-`dl` errors for HD-BET; the `introspection` param-coverage test passes; `clippy --workspace --all-targets -D warnings` is clean.
- `test_mask_hd_bet` (ignored by default, downloads weights) runs HD-BET through `qsmxt mask`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)