### PR TITLE
chore: bump qsm-core to v0.32.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,7 +2258,7 @@ dependencies = [
 [[package]]
 name = "qsm-core"
 version = "0.0.0"
-source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.31.0#7798f90a870e11c808a2cd540b2115b912d2275b"
+source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.32.0#99e799cdacbbb98e86102dddd55ee56603743d14"
 dependencies = [
  "bytemuck",
  "delaunator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = ["dl"]
 dl = ["qsm-core/onnx", "qsm-core/download"]
 
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.31.0", features = ["parallel"] }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.32.0", features = ["parallel"] }
 qsmxt-config = { path = "crates/qsmxt-config" }
 clap = { version = "4", features = ["derive"] }
 const_format = "0.2"

--- a/crates/qsmxt-config/Cargo.toml
+++ b/crates/qsmxt-config/Cargo.toml
@@ -6,7 +6,7 @@ description = "Pipeline configuration, command generation, and methods text for 
 license = "GPL-3.0-only"
 
 [dependencies]
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.31.0" }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.32.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"


### PR DESCRIPTION
Picks up [qsm-core v0.32.0](https://github.com/astewartau/QSM.rs/releases/tag/v0.32.0):

- **`pipeline::apply_mask_ops`** — one implementation of what the mask operations mean, now public so hosts that drive masking themselves (an interactive UI applying one refinement per click) run the same code this pipeline does instead of reimplementing it. `build_mask_section` is that function starting from an all-ones mask, so **masks are unchanged here**.
- **Multithreaded ONNX inference on WASM** — no effect on qsmxt, which is native.

No qsmxt-side changes are needed. The bump is what lets QSMbly drop its own JavaScript mask morphology and call the same code, so signal-gated erosion behaves identically in the browser and in qsmxt.

## Checks
Workspace tests pass (565 + 105) and `clippy --workspace --all-targets -D warnings` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)